### PR TITLE
Add missing requirement and an initial gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,97 @@
+*.csv
+todo.txt
+*.json
+*.sqlite
+
+.cache/
+cache/
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# IPython Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# dotenv
+.env
+
+# virtualenv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+
+# Rope project settings
+.ropeproject

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 requests
 docopt
 publicsuffix
+py3dns
 pyspf==2.0.11


### PR DESCRIPTION
To improve the local dev experience, this -

* Adds `py3dns` to `requirements.txt`, as it is a dependency (and it's already in `setup.py`).
* Adds an initial `.gitignore` file, using `pshtt`'s as a base. This addressed the files I was already encountering locally, around Python egg compilation and CSV generation.