### PR TITLE
Added support for STARTTLS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,14 +91,14 @@ The following values are returned in `results.csv`:
 * `Mail Servers` - The list of hosts found in the MX record.
 * `Mail Server Ports Tested` - A list of the ports tested for SMTP and
   STARTTLS support.
-* `Domain Supports SMTP Results` - A list of the mail server and port
-  combinations that support SMTP.
 * `Domain Supports SMTP` - True if and only if __any__ mail servers
   specified in a MX record associated with the domain supports SMTP.
-* `Domain Supports STARTTLS Results` - A list of the mail server and
-  port combinations that support STARTTLS.
+* `Domain Supports SMTP Results` - A list of the mail server and port
+  combinations that support SMTP.
 * `Domain Supports STARTTLS` - True if and only if __all__ mail
   servers that support SMTP also support STARTTLS.
+* `Domain Supports STARTTLS Results` - A list of the mail server and
+  port combinations that support STARTTLS.
 
 #### SPF
 

--- a/README.md
+++ b/README.md
@@ -84,13 +84,14 @@ The following values are returned in `results.csv`:
 * `Mail Servers` - The list of hosts found in the MX record.
 * `Mail Server Ports Tested` - A list of the ports tested for SMTP and
   STARTTLS support.
-* `Mail Server Is Listening` - If the mail servers are actually
-  listening on the tested ports.
-* `Mail Server Supports SMTP` - If the mail servers support SMTP.
-* `Mail Server Supports STARTTLS` - If the mail servers support
-  STARTTLS.
-* `Domain Supports STARTTLS` - True if all mail servers that support
-  SMTP also support STARTTLS, and otherwise false.
+* `Domain Supports SMTP Results` - A list of the mail server and port
+  combinations that support SMTP.
+* `Domain Supports SMTP` - True if and only if __any__ mail servers
+  specified in a MX record associated with the domain supports SMTP.
+* `Domain Supports STARTTLS Results` - A list of the mail server and
+  port combinations that support STARTTLS.
+* `Domain Supports STARTTLS` - True if and only if __all__ mail
+  servers that support SMTP also support STARTTLS.
 
 #### SPF
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,16 @@ Note: if INPUT ends with `.csv`, domains will be read from CSV. CSV output will 
 ```bash
   -h --help                   Show this message.
   -o --output=OUTFILE         Name of output file. (Default results)
-  -t --timeout=TIMEOUT        The DNS lookup and SMTP connection timeout in seconds. (Default is 5.)
+  -t --timeout=TIMEOUT        The DNS lookup timeout in seconds. (Default is 5.)
+  --smtp-timeout=TIMEOUT      The SMTP connection timeout in seconds. (Default is 5.)
+  --smtp-localhost=HOSTNAME   The hostname to use when connecting to SMTP 
+                              servers.  (Default is the FQDN of the host from
+                              which trustymail is being run.)
+  --smtp-ports=PORTS          A comma-delimited list of ports at which to look 
+                              for SMTP servers.  (Default is "25,465,587".)
+  --no-smtp-cache             Do not cache SMTP results during the run.  This 
+                              may results in slower scans due to testing the 
+                              same mail servers multiple times.
   --mx                        Only check mx records
   --starttls                  Only check mx records and STARTTLS support.  (Implies --mx.)
   --spf                       Only check spf records
@@ -45,8 +54,10 @@ The following values are returned in `results.csv`:
 
 * `MX Record` - If an MX record was found that contains at least a single mail server.
 * `Mail Servers` - The list of hosts found in the MX record.
-* `Sends Mail` - If the mail servers are actually SMTP servers.
-* `Supports STARTTLS` - If the mail servers support STARTTLS.
+* `Mail Server Ports Tested` - A list of the ports tested for SMTP and STARTTLS support.
+* `Mail Server Is Listening` - If the mail servers are actually listening on the tested ports.
+* `Mail Server Supports SMTP` - If the mail servers support SMTP.
+* `Mail Server Supports STARTTLS` - If the mail servers support STARTTLS.
 
 #### SPF
 * `SPF Record` - Whether or not a SPF record was found.

--- a/README.md
+++ b/README.md
@@ -79,12 +79,18 @@ The following values are returned in `results.csv`:
 
 #### Mail sending
 
-* `MX Record` - If an MX record was found that contains at least a single mail server.
+* `MX Record` - If an MX record was found that contains at least a
+  single mail server.
 * `Mail Servers` - The list of hosts found in the MX record.
-* `Mail Server Ports Tested` - A list of the ports tested for SMTP and STARTTLS support.
-* `Mail Server Is Listening` - If the mail servers are actually listening on the tested ports.
+* `Mail Server Ports Tested` - A list of the ports tested for SMTP and
+  STARTTLS support.
+* `Mail Server Is Listening` - If the mail servers are actually
+  listening on the tested ports.
 * `Mail Server Supports SMTP` - If the mail servers support SMTP.
-* `Mail Server Supports STARTTLS` - If the mail servers support STARTTLS.
+* `Mail Server Supports STARTTLS` - If the mail servers support
+  STARTTLS.
+* `Domain Supports STARTTLS` - True if all mail servers that support
+  SMTP also support STARTTLS, and otherwise false.
 
 #### SPF
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ Note: if INPUT ends with `.csv`, domains will be read from CSV. CSV output will 
   -h --help                   Show this message.
   -o --output=OUTFILE         Name of output file. (Default results)
   -t --timeout=TIMEOUT        The DNS lookup timeout in seconds. (Default is 5.)
-  --smtp-timeout=TIMEOUT      The SMTP connection timeout in seconds. (Default is 5.)
+  --smtp-timeout=TIMEOUT      The SMTP connection timeout in seconds. (Default 
+                              is 5.)
   --smtp-localhost=HOSTNAME   The hostname to use when connecting to SMTP 
                               servers.  (Default is the FQDN of the host from
                               which trustymail is being run.)
@@ -59,7 +60,8 @@ Note: if INPUT ends with `.csv`, domains will be read from CSV. CSV output will 
                               may results in slower scans due to testing the 
                               same mail servers multiple times.
   --mx                        Only check mx records
-  --starttls                  Only check mx records and STARTTLS support.  (Implies --mx.)
+  --starttls                  Only check mx records and STARTTLS support. 
+                              (Implies --mx.)
   --spf                       Only check spf records
   --dmarc                     Only check dmarc records
   --debug                     Output should include error messages.
@@ -67,14 +69,19 @@ Note: if INPUT ends with `.csv`, domains will be read from CSV. CSV output will 
 
 ## What's Checked?
 
-For a given domain, MX records, SPF records (TXT), DMARC (TXT, at \_dmarc.<domain>), and support for STARTTLS are checked.
+For a given domain, MX records, SPF records (TXT), DMARC (TXT, at
+\_dmarc.<domain>), and support for STARTTLS are checked.
 
 The following values are returned in `results.csv`:
 
 #### Domain and redirect info
 
 * `Domain` - The domain you're scanning!
-* `Base Domain` - The base domain of `Domain`. For example, for a Domain of `sub.example.gov`, the Base Domain will be `example.gov`. Usually this is the second-level domain, but `trustymail` will download and factor in the [Public Suffix List](https://publicsuffix.org) when calculating the base domain.
+* `Base Domain` - The base domain of `Domain`. For example, for a
+  Domain of `sub.example.gov`, the Base Domain will be
+  `example.gov`. Usually this is the second-level domain, but
+  `trustymail` will download and factor in the [Public Suffix
+  List](https://publicsuffix.org) when calculating the base domain.
 * `Live` - The domain is actually published in the DNS.
 
 #### Mail sending
@@ -96,25 +103,43 @@ The following values are returned in `results.csv`:
 #### SPF
 
 * `SPF Record` - Whether or not a SPF record was found.
-* `Valid SPF` - Whether the SPF record found is syntactically correct, per RFC 4408 .
-* `SPF Results` -  The textual representation of any SPF record found for the domain.
+* `Valid SPF` - Whether the SPF record found is syntactically correct,
+  per RFC 4408.
+* `SPF Results` - The textual representation of any SPF record found
+  for the domain.
 
 #### DMARC
 
 * `DMARC Record` - True/False whether or not a DMARC record was found.
-* `Valid DMARC` - Whether the DMARC record found is syntactically correct.
-* `DMARC Results` - The DMARC record that was discovered when querying DNS.
-* `DMARC Record on Base Domain`, `Valid DMARC Record on Base Domain`, `DMARC Results on Base Domain` - Same definition as above, but returns the result for the Base Domain. This is important in DMARC because if there isn't a DMARC record at the domain, the base domain (or "Organizational Domain", per [RFC 7489](https://tools.ietf.org/html/rfc7489#section-6.6.3), is checked and applied.)
-* `DMARC Policy` - An adjudication, based on any policies found in `DMARC Results` and `DMARC Results on Base Domain`, of the relevant DMARC policy that applies.
+* `Valid DMARC` - Whether the DMARC record found is syntactically
+  correct.
+* `DMARC Results` - The DMARC record that was discovered when querying
+  DNS.
+* `DMARC Record on Base Domain`, `Valid DMARC Record on Base Domain`,
+  `DMARC Results on Base Domain` - Same definition as above, but
+  returns the result for the Base Domain. This is important in DMARC
+  because if there isn't a DMARC record at the domain, the base domain
+  (or "Organizational Domain", per [RFC
+  7489](https://tools.ietf.org/html/rfc7489#section-6.6.3)), is
+  checked and applied.
+* `DMARC Policy` - An adjudication, based on any policies found in
+  `DMARC Results` and `DMARC Results on Base Domain`, of the relevant
+  DMARC policy that applies.
 
-#### etc.
+#### Etc.
 
-* `Syntax Errors` - A list of syntax errors that were detected when scanning DMARC or SPF records, or checking for STARTTLS support.
+* `Syntax Errors` - A list of syntax errors that were detected when
+  scanning DMARC or SPF records, or checking for STARTTLS support.
 
 ## Public domain
 
 This project is in the worldwide [public domain](LICENSE.md).
 
-This project is in the public domain within the United States, and copyright and related rights in the work worldwide are waived through the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/).
+This project is in the public domain within the United States, and
+copyright and related rights in the work worldwide are waived through
+the [CC0 1.0 Universal public domain
+dedication](https://creativecommons.org/publicdomain/zero/1.0/).
 
-All contributions to this project will be released under the CC0 dedication. By submitting a pull request, you are agreeing to comply with this waiver of copyright interest.
+All contributions to this project will be released under the CC0
+dedication. By submitting a pull request, you are agreeing to comply
+with this waiver of copyright interest.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## Trustworthy Mail
-`trustymail` is a tool that evaluates SPF/DMARC records set in a domain's DNS. It saves its results to CSV or JSON.
+`trustymail` is a tool that evaluates SPF/DMARC records set in a domain's DNS. It also checks the mail servers listed in a domain's MX records for STARTTLS support. It saves its results to CSV or JSON.
 
 #### Installation
 Clone the repo, then
@@ -22,15 +22,16 @@ Note: if INPUT ends with `.csv`, domains will be read from CSV. CSV output will 
 ```bash
   -h --help                   Show this message.
   -o --output=OUTFILE         Name of output file. (Default results)
-  -t --timeout=TIMEOUT        Override timeout of DNS lookup in seconds. (Default 5)
+  -t --timeout=TIMEOUT        The DNS lookup and SMTP connection timeout in seconds. (Default is 5.)
   --mx                        Only check mx records
+  --starttls                  Only check mx records and STARTTLS support.  (Implies --mx.)
   --spf                       Only check spf records
   --dmarc                     Only check dmarc records
   --debug                     Output should include error messages.
 ```
 
 ## What's Checked?
-For a given domain, MX records, SPF records (TXT), and DMARC (TXT, at \_dmarc.<domain>) are checked.
+For a given domain, MX records, SPF records (TXT), DMARC (TXT, at \_dmarc.<domain>), and support for STARTTLS are checked.
 
 The following values are returned in `results.csv`:
 
@@ -44,6 +45,8 @@ The following values are returned in `results.csv`:
 
 * `MX Record` - If an MX record was found that contains at least a single mail server.
 * `Mail Servers` - The list of hosts found in the MX record.
+* `Sends Mail` - If the mail servers are actually SMTP servers.
+* `Supports STARTTLS` - If the mail servers support STARTTLS.
 
 #### SPF
 * `SPF Record` - Whether or not a SPF record was found.
@@ -58,7 +61,7 @@ The following values are returned in `results.csv`:
 * `DMARC Policy` - An adjudication, based on any policies found in `DMARC Results` and `DMARC Results on Base Domain`, of the relevant DMARC policy that applies.
 
 #### etc.
-* `Syntax Errors` - A list of syntax errors that were detected when scanning either DMARC or SPF records.
+* `Syntax Errors` - A list of syntax errors that were detected when scanning DMARC or SPF records, or checking for STARTTLS support.
 
 ## Public domain
 

--- a/trustymail/cli.py
+++ b/trustymail/cli.py
@@ -1,13 +1,14 @@
 """TrustyMail A tool for scanning DNS mail records for evaluating security.
 Usage:
   trustymail (INPUT ...) [options]
-  trustymail (INPUT ...) [--output=OUTFILE] [--timeout=TIMEOUT] [--mx] [--spf] [--dmarc] [--debug] [--json]
+  trustymail (INPUT ...) [--output=OUTFILE] [--timeout=TIMEOUT] [--mx] [--starttls] [--spf] [--dmarc] [--debug] [--json]
   trustymail (-h | --help)
 Options:
   -h --help                   Show this message.
   -o --output=OUTFILE         Name of output file. (Default results)
-  -t --timeout=TIMEOUT        Override timeout of DNS lookup in seconds. (Default 5)
+  -t --timeout=TIMEOUT        The DNS lookup and SMTP connection timeout in seconds. (Default is 5.)
   --mx                        Only check mx records
+  --starttls                  Only check mx records and STARTTLS support.  (Implies --mx.)
   --spf                       Only check spf records
   --dmarc                     Only check dmarc records
   --json                      Output is in json format (default csv)
@@ -44,9 +45,14 @@ def main():
     else:
         timeout = 5
 
+    # --starttls implies --mx
+    if args["--starttls"]:
+        args["--mx"] = True
+
     # User might not want every scan performed.
     scan_types = {
                     "mx": args["--mx"],
+                    "starttls": args["--starttls"],
                     "spf": args["--spf"],
                     "dmarc": args["--dmarc"]
                  }

--- a/trustymail/cli.py
+++ b/trustymail/cli.py
@@ -68,7 +68,7 @@ def main():
         smtp_localhost = None
 
     if args["--smtp-ports"] is not None:
-        smtp_ports = list(map(lambda x:int(x), args["--smtp-ports"].split(',')))
+        smtp_ports = [int(port) for port in args['--smtp-ports'].split(',')]
     else:
         smtp_ports = _DEFAULT_SMTP_PORTS
 

--- a/trustymail/cli.py
+++ b/trustymail/cli.py
@@ -37,7 +37,7 @@ from trustymail import trustymail
 base_domains = {}
 
 # The default ports to be checked to see if an SMTP server is listening.
-_DEFAULT_SMTP_PORTS = [25, 465, 587]
+_DEFAULT_SMTP_PORTS = {25, 465, 587}
 
 
 def main():
@@ -68,7 +68,7 @@ def main():
         smtp_localhost = None
 
     if args["--smtp-ports"] is not None:
-        smtp_ports = [int(port) for port in args['--smtp-ports'].split(',')]
+        smtp_ports = {int(port) for port in args['--smtp-ports'].split(',')}
     else:
         smtp_ports = _DEFAULT_SMTP_PORTS
 

--- a/trustymail/cli.py
+++ b/trustymail/cli.py
@@ -1,12 +1,16 @@
 """TrustyMail A tool for scanning DNS mail records for evaluating security.
 Usage:
   trustymail (INPUT ...) [options]
-  trustymail (INPUT ...) [--output=OUTFILE] [--timeout=TIMEOUT] [--mx] [--starttls] [--spf] [--dmarc] [--debug] [--json]
+  trustymail (INPUT ...) [--output=OUTFILE] [--timeout=TIMEOUT] [--smtp-timeout=TIMEOUT] [--smtp-localhost=HOSTNAME] [--mx] [--starttls] [--spf] [--dmarc] [--debug] [--json]
   trustymail (-h | --help)
 Options:
   -h --help                   Show this message.
   -o --output=OUTFILE         Name of output file. (Default results)
-  -t --timeout=TIMEOUT        The DNS lookup and SMTP connection timeout in seconds. (Default is 5.)
+  -t --timeout=TIMEOUT        The DNS lookup timeout in seconds. (Default is 5.)
+  --smtp-timeout=TIMEOUT      The SMTP connection timeout in seconds. (Default is 5.)
+  --smtp-localhost=HOSTNAME   The hostname to use when connecting to SMTP 
+                              servers.  (Default is the FQDN of the host from
+                              which trustymail is being run.)
   --mx                        Only check mx records
   --starttls                  Only check mx records and STARTTLS support.  (Implies --mx.)
   --spf                       Only check spf records
@@ -45,6 +49,16 @@ def main():
     else:
         timeout = 5
 
+    if args["--smtp-timeout"] is not None:
+        smtp_timeout = int(args["--smtp-timeout"])
+    else:
+        smtp_timeout = 5
+
+    if args["--smtp-localhost"] is not None:
+        smtp_localhost = args["--smtp-localhost"]
+    else:
+        smtp_localhost = None
+
     # --starttls implies --mx
     if args["--starttls"]:
         args["--mx"] = True
@@ -59,7 +73,9 @@ def main():
 
     domain_scans = []
     for domain_name in domains:
-        domain_scans.append(trustymail.scan(domain_name, timeout, scan_types))
+        domain_scans.append(trustymail.scan(domain_name, timeout,
+                                            smtp_timeout, smtp_localhost,
+                                            scan_types))
 
     # Default output file name is results.
     if args["--output"] is None:

--- a/trustymail/domain.py
+++ b/trustymail/domain.py
@@ -41,33 +41,37 @@ class Domain:
         # Mail Info
         self.mail_servers = []
 
-        # A string for each port for each entry in mail_servers indicating
-        # whether or not the server supports SMTP
-        self.supports_smtp = []
-
-        # A string for each port for each entry in mail_servers indicating
-        # whether or not the server supports STARTTLS
-        self.starttls = []
+        # A dictionary for each port for each entry in mail_servers.
+        # The dictionary's values indicate:
+        # 1. Whether or not the server is listening on the port
+        # 2. Whether or not the server supports SMTP
+        # 3. Whether or not the server supports STARTTLS
+        self.starttls_results = {}
 
         # A list of any errors that occurred while scanning records.
         self.errors = []
+
+        # A list of the ports tested for SMTP
+        self.ports_tested = []
 
     def has_mail(self):
         return len(self.mail_servers) > 0
 
     def has_supports_smtp(self):
         """
-        Returns True if information about whether servers support
-        SMTP is present and otherwise returns False.
+        Returns True if any of the mail servers associated with this
+        domain are listening and support SMTP.
         """
-        return len(self.supports_smtp) > 0
+        return len(filter(lambda x:self.starttls_results[x]["supports_smtp"],
+                          self.starttls_results.keys())) > 0
 
     def has_starttls(self):
         """
-        Returns True if STARTTLS information is present and otherwise
-        returns False.
+        Returns True if any of the mail servers associated with this
+        domain are listening and support STARTTLS.
         """
-        return len(self.starttls) > 0
+        return len(filter(lambda x:self.starttls_results[x]["starttls"],
+                          self.starttls_results.keys())) > 0
 
     def has_spf(self):
         return len(self.spf) > 0
@@ -112,8 +116,10 @@ class Domain:
 
                         "MX Record": self.has_mail(),
                         "Mail Servers": self.format_list(self.mail_servers),
-                        "Supports SMTP": self.format_list(self.supports_smtp),
-                        "Supports STARTTLS": self.format_list(self.starttls),
+                        "Mail Server Ports Tested": self.format_list(list(map(lambda x:str(x), self.ports_tested))),
+                        "Mail Server Is Listening": self.format_list(list(map(lambda x:x + ";" + str(self.starttls_results[x]["is_listening"]), self.starttls_results.keys()))),
+                        "Mail Server Supports SMTP": self.format_list(list(map(lambda x:x + ";" + str(self.starttls_results[x]["supports_smtp"]), self.starttls_results.keys()))),
+                        "Mail Server Supports STARTTLS": self.format_list(list(map(lambda x:x + ";" + str(self.starttls_results[x]["starttls"]), self.starttls_results.keys()))),
 
                         "SPF Record": self.has_spf(),
                         "Valid SPF": self.valid_spf,

--- a/trustymail/domain.py
+++ b/trustymail/domain.py
@@ -109,6 +109,10 @@ class Domain:
 
 
     def generate_results(self):
+        mail_servers_that_are_listening = [x for x in self.starttls_results.keys() if self.starttls_results[x]["is_listening"]]
+        mail_servers_that_support_smtp = [x for x in self.starttls_results.keys() if self.starttls_results[x]["supports_smtp"]]
+        mail_servers_that_support_starttls = [x for x in self.starttls_results.keys() if self.starttls_results[x]["starttls"]]
+        
         results = {
                         "Domain": self.domain_name,
                         "Base Domain": self.base_domain_name,
@@ -117,9 +121,12 @@ class Domain:
                         "MX Record": self.has_mail(),
                         "Mail Servers": self.format_list(self.mail_servers),
                         "Mail Server Ports Tested": self.format_list([str(port) for port in self.ports_tested]),
-                        "Mail Server Is Listening": self.format_list([x for x in self.starttls_results.keys() if self.starttls_results[x]["is_listening"]]),
-                        "Mail Server Supports SMTP": self.format_list([x for x in self.starttls_results.keys() if self.starttls_results[x]["supports_smtp"]]),
-                        "Mail Server Supports STARTTLS": self.format_list([x for x in self.starttls_results.keys() if self.starttls_results[x]["starttls"]]),
+                        "Mail Server Is Listening": self.format_list(mail_servers_that_are_listening),
+                        "Mail Server Supports SMTP": self.format_list(mail_servers_that_support_smtp),
+                        "Mail Server Supports STARTTLS": self.format_list(mail_servers_that_support_starttls),
+                        # True if all mail servers that support SMTP
+                        # also support STARTTLS, and otherwise false
+                        "Domain Supports STARTTLS": bool(mail_servers_that_support_smtp) and all([self.starttls_results[x]["starttls"] for x in mail_servers_that_support_smtp]),
 
                         "SPF Record": self.has_spf(),
                         "Valid SPF": self.valid_spf,

--- a/trustymail/domain.py
+++ b/trustymail/domain.py
@@ -116,10 +116,10 @@ class Domain:
 
                         "MX Record": self.has_mail(),
                         "Mail Servers": self.format_list(self.mail_servers),
-                        "Mail Server Ports Tested": self.format_list(list(map(lambda x:str(x), self.ports_tested))),
-                        "Mail Server Is Listening": self.format_list(list(map(lambda x:x + ";" + str(self.starttls_results[x]["is_listening"]), self.starttls_results.keys()))),
-                        "Mail Server Supports SMTP": self.format_list(list(map(lambda x:x + ";" + str(self.starttls_results[x]["supports_smtp"]), self.starttls_results.keys()))),
-                        "Mail Server Supports STARTTLS": self.format_list(list(map(lambda x:x + ";" + str(self.starttls_results[x]["starttls"]), self.starttls_results.keys()))),
+                        "Mail Server Ports Tested": self.format_list([str(port) for port in self.ports_tested]),
+                        "Mail Server Is Listening": self.format_list([x + ";" + str(self.starttls_results[x]["is_listening"]) for x in self.starttls_results.keys()]),
+                        "Mail Server Supports SMTP": self.format_list([x + ";" + str(self.starttls_results[x]["supports_smtp"]) for x in self.starttls_results.keys()]),
+                        "Mail Server Supports STARTTLS": self.format_list([x + ";" + str(self.starttls_results[x]["starttls"]) for x in self.starttls_results.keys()]),
 
                         "SPF Record": self.has_spf(),
                         "Valid SPF": self.valid_spf,

--- a/trustymail/domain.py
+++ b/trustymail/domain.py
@@ -52,7 +52,7 @@ class Domain:
         self.errors = []
 
         # A list of the ports tested for SMTP
-        self.ports_tested = []
+        self.ports_tested = set()
 
     def has_mail(self):
         return len(self.mail_servers) > 0

--- a/trustymail/domain.py
+++ b/trustymail/domain.py
@@ -42,8 +42,8 @@ class Domain:
         self.mail_servers = []
 
         # A string for each port for each entry in mail_servers indicating
-        # whether or not the server sends mail
-        self.sends_mail = []
+        # whether or not the server supports SMTP
+        self.supports_smtp = []
 
         # A string for each port for each entry in mail_servers indicating
         # whether or not the server supports STARTTLS
@@ -55,12 +55,12 @@ class Domain:
     def has_mail(self):
         return len(self.mail_servers) > 0
 
-    def has_sends_mail(self):
+    def has_supports_smtp(self):
         """
-        Returns True if information about whether mail servers send
-        mail is present and otherwise returns False.
+        Returns True if information about whether servers support
+        SMTP is present and otherwise returns False.
         """
-        return len(self.starttls) > 0
+        return len(self.supports_smtp) > 0
 
     def has_starttls(self):
         """
@@ -112,7 +112,7 @@ class Domain:
 
                         "MX Record": self.has_mail(),
                         "Mail Servers": self.format_list(self.mail_servers),
-                        "Sends Mail": self.format_list(self.sends_mail),
+                        "Supports SMTP": self.format_list(self.supports_smtp),
                         "Supports STARTTLS": self.format_list(self.starttls),
 
                         "SPF Record": self.has_spf(),

--- a/trustymail/domain.py
+++ b/trustymail/domain.py
@@ -117,9 +117,9 @@ class Domain:
                         "MX Record": self.has_mail(),
                         "Mail Servers": self.format_list(self.mail_servers),
                         "Mail Server Ports Tested": self.format_list([str(port) for port in self.ports_tested]),
-                        "Mail Server Is Listening": self.format_list([x + ";" + str(self.starttls_results[x]["is_listening"]) for x in self.starttls_results.keys()]),
-                        "Mail Server Supports SMTP": self.format_list([x + ";" + str(self.starttls_results[x]["supports_smtp"]) for x in self.starttls_results.keys()]),
-                        "Mail Server Supports STARTTLS": self.format_list([x + ";" + str(self.starttls_results[x]["starttls"]) for x in self.starttls_results.keys()]),
+                        "Mail Server Is Listening": self.format_list([x for x in self.starttls_results.keys() if self.starttls_results[x]["is_listening"]]),
+                        "Mail Server Supports SMTP": self.format_list([x for x in self.starttls_results.keys() if self.starttls_results[x]["supports_smtp"]]),
+                        "Mail Server Supports STARTTLS": self.format_list([x for x in self.starttls_results.keys() if self.starttls_results[x]["starttls"]]),
 
                         "SPF Record": self.has_spf(),
                         "Valid SPF": self.valid_spf,

--- a/trustymail/domain.py
+++ b/trustymail/domain.py
@@ -41,11 +41,33 @@ class Domain:
         # Mail Info
         self.mail_servers = []
 
+        # A string for each port for each entry in mail_servers indicating
+        # whether or not the server sends mail
+        self.sends_mail = []
+
+        # A string for each port for each entry in mail_servers indicating
+        # whether or not the server supports STARTTLS
+        self.starttls = []
+
         # A list of any errors that occurred while scanning records.
         self.errors = []
 
     def has_mail(self):
         return len(self.mail_servers) > 0
+
+    def has_sends_mail(self):
+        """
+        Returns True if information about whether mail servers send
+        mail is present and otherwise returns False.
+        """
+        return len(self.starttls) > 0
+
+    def has_starttls(self):
+        """
+        Returns True if STARTTLS information is present and otherwise
+        returns False.
+        """
+        return len(self.starttls) > 0
 
     def has_spf(self):
         return len(self.spf) > 0
@@ -90,6 +112,8 @@ class Domain:
 
                         "MX Record": self.has_mail(),
                         "Mail Servers": self.format_list(self.mail_servers),
+                        "Sends Mail": self.format_list(self.sends_mail),
+                        "Supports STARTTLS": self.format_list(self.starttls),
 
                         "SPF Record": self.has_spf(),
                         "Valid SPF": self.valid_spf,

--- a/trustymail/domain.py
+++ b/trustymail/domain.py
@@ -112,38 +112,39 @@ class Domain:
         mail_servers_that_are_listening = [x for x in self.starttls_results.keys() if self.starttls_results[x]["is_listening"]]
         mail_servers_that_support_smtp = [x for x in self.starttls_results.keys() if self.starttls_results[x]["supports_smtp"]]
         mail_servers_that_support_starttls = [x for x in self.starttls_results.keys() if self.starttls_results[x]["starttls"]]
+        domain_supports_smtp = bool(mail_servers_that_support_starttls)
         
         results = {
-                        "Domain": self.domain_name,
-                        "Base Domain": self.base_domain_name,
-                        "Live": self.is_live,
+            "Domain": self.domain_name,
+            "Base Domain": self.base_domain_name,
+            "Live": self.is_live,
 
-                        "MX Record": self.has_mail(),
-                        "Mail Servers": self.format_list(self.mail_servers),
-                        "Mail Server Ports Tested": self.format_list([str(port) for port in self.ports_tested]),
-                        "Mail Server Is Listening": self.format_list(mail_servers_that_are_listening),
-                        "Mail Server Supports SMTP": self.format_list(mail_servers_that_support_smtp),
-                        "Mail Server Supports STARTTLS": self.format_list(mail_servers_that_support_starttls),
-                        # True if all mail servers that support SMTP
-                        # also support STARTTLS, and otherwise false
-                        "Domain Supports STARTTLS": bool(mail_servers_that_support_smtp) and all([self.starttls_results[x]["starttls"] for x in mail_servers_that_support_smtp]),
+            "MX Record": self.has_mail(),
+            "Mail Servers": self.format_list(self.mail_servers),
+            "Mail Server Ports Tested": self.format_list([str(port) for port in self.ports_tested]),
+            "Domain Supports SMTP Results": self.format_list(mail_servers_that_support_smtp),
+            # True if and only if at least one mail server speaks SMTP
+            "Domain Supports SMTP": domain_supports_smtp,
+            "Domain Supports STARTTLS Results": self.format_list(mail_servers_that_support_starttls),
+            # True if and only if all mail servers that speak SMTP
+            # also support STARTTLS
+            "Domain Supports STARTTLS": domain_supports_smtp and all([self.starttls_results[x]["starttls"] for x in mail_servers_that_support_smtp]),
 
-                        "SPF Record": self.has_spf(),
-                        "Valid SPF": self.valid_spf,
-                        "SPF Results": self.format_list(self.spf),
+            "SPF Record": self.has_spf(),
+            "Valid SPF": self.valid_spf,
+            "SPF Results": self.format_list(self.spf),
 
-                        "DMARC Record": self.has_dmarc(),
-                        "Valid DMARC": self.has_dmarc() and self.valid_dmarc,
-                        "DMARC Results": self.format_list(self.dmarc),
+            "DMARC Record": self.has_dmarc(),
+            "Valid DMARC": self.has_dmarc() and self.valid_dmarc,
+            "DMARC Results": self.format_list(self.dmarc),
 
-                        "DMARC Record on Base Domain": self.parent_has_dmarc(),
-                        "Valid DMARC Record on Base Domain": self.parent_has_dmarc() and self.parent_valid_dmarc(),
-                        "DMARC Results on Base Domain": self.parent_dmarc_results(),
-                        "DMARC Policy": self.get_dmarc_policy(),
-
-                        "Syntax Errors": self.format_list(self.syntax_errors)
-
-                  }
+            "DMARC Record on Base Domain": self.parent_has_dmarc(),
+            "Valid DMARC Record on Base Domain": self.parent_has_dmarc() and self.parent_valid_dmarc(),
+            "DMARC Results on Base Domain": self.parent_dmarc_results(),
+            "DMARC Policy": self.get_dmarc_policy(),
+            
+            "Syntax Errors": self.format_list(self.syntax_errors)
+            }
 
         return results
 

--- a/trustymail/trustymail.py
+++ b/trustymail/trustymail.py
@@ -98,7 +98,9 @@ def starttls_scan(domain, smtp_timeout, smtp_localhost, smtp_ports, smtp_cache):
     """
     for mail_server in domain.mail_servers:
         for port in smtp_ports:
-            domain.ports_tested.append(port)
+            if port not in domain.ports_tested:
+                domain.ports_tested.append(port)
+            
             server_and_port = mail_server + ":" + str(port)
 
             if not smtp_cache or (server_and_port not in _SMTP_CACHE):

--- a/trustymail/trustymail.py
+++ b/trustymail/trustymail.py
@@ -16,8 +16,8 @@ from trustymail.domain import Domain
 CSV_HEADERS = [
     "Domain", "Base Domain", "Live",
     "MX Record", "Mail Servers", "Mail Server Ports Tested",
-    "Mail Server Is Listening", "Mail Server Supports SMTP",
-    "Mail Server Supports STARTTLS", "Domain Supports STARTTLS",
+    "Domain Supports SMTP Results", "Domain Supports SMTP",
+    "Domain Supports STARTTLS Results", "Domain Supports STARTTLS",
     "SPF Record", "Valid SPF", "SPF Results",
     "DMARC Record", "Valid DMARC", "DMARC Results",
     "DMARC Record on Base Domain", "Valid DMARC Record on Base Domain",

--- a/trustymail/trustymail.py
+++ b/trustymail/trustymail.py
@@ -284,7 +284,8 @@ def scan(domain_name, timeout, smtp_timeout, smtp_localhost, smtp_ports, smtp_ca
         dmarc_scan(domain)
 
     # If the user didn't specify any scans then run a full scan.
-    if not (scan_types["mx"] or scan_types["starttls"] or scan_types["spf"] or scan_types["dmarc"]):
+    if domain.is_live and not (scan_types["mx"] or scan_types["starttls"]
+                                   or scan_types["spf"] or scan_types["dmarc"]):
         mx_scan(domain)
         starttls_scan(domain, smtp_timeout, smtp_localhost, smtp_ports, smtp_cache)
         spf_scan(domain)

--- a/trustymail/trustymail.py
+++ b/trustymail/trustymail.py
@@ -16,8 +16,8 @@ from trustymail.domain import Domain
 CSV_HEADERS = [
     "Domain", "Base Domain", "Live",
     "MX Record", "Mail Servers", "Mail Server Ports Tested",
-    "Domain Supports SMTP Results", "Domain Supports SMTP",
-    "Domain Supports STARTTLS Results", "Domain Supports STARTTLS",
+    "Domain Supports SMTP", "Domain Supports SMTP Results",
+    "Domain Supports STARTTLS", "Domain Supports STARTTLS Results",
     "SPF Record", "Valid SPF", "SPF Results",
     "DMARC Record", "Valid DMARC", "DMARC Results",
     "DMARC Record on Base Domain", "Valid DMARC Record on Base Domain",

--- a/trustymail/trustymail.py
+++ b/trustymail/trustymail.py
@@ -117,7 +117,10 @@ def starttls_scan(domain, smtp_timeout, smtp_localhost, smtp_ports, smtp_cache):
                     domain.starttls_results[server_and_port]["is_listening"] = False
                     domain.starttls_results[server_and_port]["supports_smtp"] = False
                     domain.starttls_results[server_and_port]["starttls"] = False
-                    _SMTP_CACHE[server_and_port] = domain.starttls_results[server_and_port]
+
+                    if smtp_cache:
+                        _SMTP_CACHE[server_and_port] = domain.starttls_results[server_and_port]
+                    
                     continue
 
                 # Now try to say hello.  This will tell us if the
@@ -137,7 +140,9 @@ def starttls_scan(domain, smtp_timeout, smtp_localhost, smtp_ports, smtp_cache):
                     except smtplib.SMTPServerDisconnected as error2:
                         handle_error("[STARTTLS]", domain, error2)
                         
-                    _SMTP_CACHE[server_and_port] = domain.starttls_results[server_and_port]
+                    if smtp_cache:
+                        _SMTP_CACHE[server_and_port] = domain.starttls_results[server_and_port]
+                    
                     continue
 
                 # Now check if the server supports STARTTLS.
@@ -153,8 +158,9 @@ def starttls_scan(domain, smtp_timeout, smtp_localhost, smtp_ports, smtp_cache):
                 except smtplib.SMTPServerDisconnected as error:
                     handle_error("[STARTTLS]", domain, error)
 
-                # Copy the results into the cache
-                _SMTP_CACHE[server_and_port] = domain.starttls_results[server_and_port]
+                # Copy the results into the cache, if necessary
+                if smtp_cache:
+                    _SMTP_CACHE[server_and_port] = domain.starttls_results[server_and_port]
             else:
                 logging.debug("\tUsing cached results for " + server_and_port)
                 # Copy the cached results into the domain object

--- a/trustymail/trustymail.py
+++ b/trustymail/trustymail.py
@@ -98,9 +98,7 @@ def starttls_scan(domain, smtp_timeout, smtp_localhost, smtp_ports, smtp_cache):
     """
     for mail_server in domain.mail_servers:
         for port in smtp_ports:
-            if port not in domain.ports_tested:
-                domain.ports_tested.append(port)
-            
+            domain.ports_tested.add(port)
             server_and_port = mail_server + ":" + str(port)
 
             if not smtp_cache or (server_and_port not in _SMTP_CACHE):

--- a/trustymail/trustymail.py
+++ b/trustymail/trustymail.py
@@ -15,7 +15,7 @@ from trustymail.domain import Domain
 
 CSV_HEADERS = [
     "Domain", "Base Domain", "Live",
-    "MX Record", "Mail Servers", "Sends Mail", "Supports STARTTLS",
+    "MX Record", "Mail Servers", "Supports SMTP", "Supports STARTTLS",
     "SPF Record", "Valid SPF", "SPF Results",
     "DMARC Record", "Valid DMARC", "DMARC Results",
     "DMARC Record on Base Domain", "Valid DMARC Record on Base Domain",
@@ -70,10 +70,10 @@ def mx_scan(domain):
 
 def starttls_scan(domain, smtp_timeout, smtp_localhost):
     """
-    Scan a domain to see if it sends mail and supports STARTTLS.
+    Scan a domain to see if it supports SMTP and supports STARTTLS.
 
-    Scan a domain to see if it sends mail.  If the domain does send
-    mail, a further check will be done to see if it supports STARTTLS.
+    Scan a domain to see if it supports SMTP.  If the domain does support
+    SMTP, a further check will be done to see if it supports STARTTLS.
     All results are stored inside the Domain object that is passed in
     as a parameter.
 
@@ -102,7 +102,7 @@ def starttls_scan(domain, smtp_timeout, smtp_localhost):
             except (socket.timeout, smtplib.SMTPConnectError, smtplib.SMTPServerDisconnected, ConnectionRefusedError, OSError) as error:
                 handle_error("[STARTTLS]", domain, error)
                 tmp = server_and_port + "-" + str(False)
-                domain.sends_mail.append(tmp)
+                domain.supports_smtp.append(tmp)
                 domain.starttls.append(tmp)
                 continue
 
@@ -113,7 +113,7 @@ def starttls_scan(domain, smtp_timeout, smtp_localhost):
             except (smtplib.SMTPHeloError, smtplib.SMTPServerDisconnected) as error:
                 handle_error("[STARTTLS]", domain, error)
                 tmp = server_and_port + "-" + str(False)
-                domain.sends_mail.append(tmp)
+                domain.supports_smtp.append(tmp)
                 domain.starttls.append(tmp)
                 # smtplib freaks out if you call quit on a non-open
                 # connection
@@ -125,9 +125,9 @@ def starttls_scan(domain, smtp_timeout, smtp_localhost):
                 continue
 
             # We were able to connect to the server and say hello, so
-            # it must send mail.
-            domain.sends_mail.append(server_and_port + "-" + str(True))
-            logging.debug("\t Sends mail")
+            # it must support SMTP.
+            domain.supports_smtp.append(server_and_port + "-" + str(True))
+            logging.debug("\t Supports SMTP")
 
             # Now check if the server supports STARTTLS.
             has_starttls = smtp_connection.has_extn("STARTTLS")

--- a/trustymail/trustymail.py
+++ b/trustymail/trustymail.py
@@ -17,7 +17,7 @@ CSV_HEADERS = [
     "Domain", "Base Domain", "Live",
     "MX Record", "Mail Servers", "Mail Server Ports Tested",
     "Mail Server Is Listening", "Mail Server Supports SMTP",
-    "Mail Server Supports STARTTLS",
+    "Mail Server Supports STARTTLS", "Domain Supports STARTTLS",
     "SPF Record", "Valid SPF", "SPF Results",
     "DMARC Record", "Valid DMARC", "DMARC Results",
     "DMARC Record on Base Domain", "Valid DMARC Record on Base Domain",


### PR DESCRIPTION
This PR pertains to issue #5.

The CSV output now includes ~~two~~several additional columns.  "Mail Server Ports Tested" contains a comma-delimited list of the ports that were tested.  "Mail Server Is Listening" states whether a given mail server (which comes from an MX record) and port combination is listening for TCP connections. 
"Mail Server Supports SMTP", states whether a given mail server and port combination really appears to be an SMTP server.  "Mail Server Supports STARTTLS" indicates whether the mail server and port combination supports STARTTLS.  I've run most of current-federal.csv though the code, and it appears to be working.

~~The DNS timeout serves double duty as the SMTP connection timeout
value as well.~~