### PR TITLE
Revert "Output should reflect all SPF record strings, not just the first"

### DIFF
--- a/trustymail/trustymail.py
+++ b/trustymail/trustymail.py
@@ -191,7 +191,7 @@ def scan(domain_name, timeout, scan_types):
 
 def record_to_str(record):
     if isinstance(record, list):
-        record = b''.join(record)
+        record = record[0]
 
     if isinstance(record, bytes):
         record = record.decode('utf-8')


### PR DESCRIPTION
Moving too quickly and breaking things! This change didn't account for the fact that once string concatenation occurs there are no more delimiters, making "SPF Results" a bit ugly. D'oh.
```
"SPF Results": "v=spf1mxip4:208.54.243.80/32include:reflexion.net~all"
```
Reverting for now.