### PR TITLE
Empty lists are now rendered as null in the JSON output

### DIFF
--- a/trustymail/domain.py
+++ b/trustymail/domain.py
@@ -151,6 +151,6 @@ class Domain:
     def format_list(self, record_list):
 
         if not record_list:
-            return ""
+            return None
 
         return ", ".join(record_list)

--- a/trustymail/domain.py
+++ b/trustymail/domain.py
@@ -149,7 +149,10 @@ class Domain:
 
     # Format a list into a string to increase readability in CSV.
     def format_list(self, record_list):
-
+        # record_list should only be a list, not an integer, None, or
+        # anything else.  Thus this if clause handles only empty
+        # lists.  This makes a "null" appear in the JSON output for
+        # empty lists, as expected.
         if not record_list:
             return None
 


### PR DESCRIPTION
Previously they were rendered as an empty string.

This pull request should resolve #22.