### PR TITLE
Prefer dnspython to py3dns

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 ## Trustworthy Mail
 
-`trustymail` is a tool that evaluates SPF/DMARC records set in a domain's DNS. It also checks the mail servers listed in a domain's MX records for STARTTLS support. It saves its results to CSV or JSON.
+`trustymail` is a tool that evaluates SPF/DMARC records set in a
+domain's DNS. It also checks the mail servers listed in a domain's MX
+records for STARTTLS support. It saves its results to CSV or JSON.
 
 #### Installed as a module
 
@@ -18,7 +20,8 @@ trustymail [options] example.com
 
 #### Running directly
 
-To run the tool locally from the repository, without installing, first install the requirements:
+To run the tool locally from the repository, without installing, first
+install the requirements:
 
 ```bash
 pip install -r requirements.txt
@@ -41,7 +44,8 @@ trustymail --output=homeland.csv --debug dhs.gov us-cert.gov usss.gov
 trustymail agencies.csv
 ```
 
-Note: if INPUT ends with `.csv`, domains will be read from CSV. CSV output will always be written to disk, defaulting to `results.csv`.
+Note: if INPUT ends with `.csv`, domains will be read from CSV. CSV
+output will always be written to disk, defaulting to `results.csv`.
 
 #### Options
 
@@ -65,6 +69,12 @@ Note: if INPUT ends with `.csv`, domains will be read from CSV. CSV output will 
   --spf                       Only check spf records
   --dmarc                     Only check dmarc records
   --debug                     Output should include error messages.
+  --dns-hostnames=HOSTNAMES   A comma-delimited list of DNS servers to query 
+                              against.  For example, if you want to use 
+                              Google's DNS then you would use the 
+                              value --dns-hostnames='8.8.8.8,8.8.4.4'.  By 
+                              default the DNS configuration of the host OS are 
+                              used.
 ```
 
 ## What's Checked?
@@ -130,6 +140,8 @@ The following values are returned in `results.csv`:
 
 * `Syntax Errors` - A list of syntax errors that were detected when
   scanning DMARC or SPF records, or checking for STARTTLS support.
+* `Errors` - A list of any other errors encountered, such as DNS
+  failures.
 
 ## Public domain
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 requests
 docopt
 publicsuffix
+dnspython
 py3dns
 pyspf==2.0.11

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
         'requests',
         'docopt',
         'publicsuffix',
+        'dnspython',
         'py3dns',
         'pyspf==2.0.11',
     ],

--- a/trustymail/cli.py
+++ b/trustymail/cli.py
@@ -3,6 +3,7 @@ Usage:
   trustymail (INPUT ...) [options]
   trustymail (INPUT ...) [--output=OUTFILE] [--timeout=TIMEOUT] [--smtp-timeout=TIMEOUT] [--smtp-localhost=HOSTNAME] [--smtp-ports=PORTS] [--no-smtp-cache] [--mx] [--starttls] [--spf] [--dmarc] [--debug] [--json] [--dns-hostnames=HOSTNAMES]
   trustymail (-h | --help)
+
 Options:
   -h --help                   Show this message.
   -o --output=OUTFILE         Name of output file. (Default results)
@@ -24,8 +25,8 @@ Options:
   --debug                     Output should include error messages.
   --dns-hostnames=HOSTNAMES   A comma-delimited list of DNS servers to query 
                               against.  For example, if you want to use 
-                              Google's DNS then you would use 
-                              the value --dns-hostnames="8.8.8.8,8.8.4.4".  By 
+                              Google's DNS then you would use the 
+                              value --dns-hostnames='8.8.8.8,8.8.4.4'.  By 
                               default the DNS configuration of the host OS are 
                               used.
 

--- a/trustymail/cli.py
+++ b/trustymail/cli.py
@@ -1,7 +1,7 @@
 """trustymail: A tool for scanning DNS mail records for evaluating security.
 Usage:
   trustymail (INPUT ...) [options]
-  trustymail (INPUT ...) [--output=OUTFILE] [--timeout=TIMEOUT] [--smtp-timeout=TIMEOUT] [--smtp-localhost=HOSTNAME] [--smtp-ports=PORTS] [--no-smtp-cache] [--mx] [--starttls] [--spf] [--dmarc] [--debug] [--json]
+  trustymail (INPUT ...) [--output=OUTFILE] [--timeout=TIMEOUT] [--smtp-timeout=TIMEOUT] [--smtp-localhost=HOSTNAME] [--smtp-ports=PORTS] [--no-smtp-cache] [--mx] [--starttls] [--spf] [--dmarc] [--debug] [--json] [--dns-hostnames=HOSTNAMES]
   trustymail (-h | --help)
 Options:
   -h --help                   Show this message.
@@ -22,6 +22,12 @@ Options:
   --dmarc                     Only check dmarc records
   --json                      Output is in json format (default csv)
   --debug                     Output should include error messages.
+  --dns-hostnames=HOSTNAMES   A comma-delimited list of DNS servers to query 
+                              against.  For example, if you want to use 
+                              Google's DNS then you would use 
+                              the value --dns-hosts="8.8.8.8,8.8.4.4".  By 
+                              default the DNS configuration of the host OS are 
+                              used.
 
 Notes:
    If no scan type options are specified, all are run against a given domain/input.
@@ -73,6 +79,11 @@ def main():
     else:
         smtp_ports = _DEFAULT_SMTP_PORTS
 
+    if args["--dns-hostnames"] is not None:
+        dns_hostnames = args['--dns-hostnames'].split(',')
+    else:
+        dns_hostnames = None
+
     # --starttls implies --mx
     if args["--starttls"]:
         args["--mx"] = True
@@ -90,7 +101,7 @@ def main():
         domain_scans.append(trustymail.scan(domain_name, timeout,
                                             smtp_timeout, smtp_localhost,
                                             smtp_ports, not args["--no-smtp-cache"],
-                                            scan_types))
+                                            scan_types, dns_hostnames))
 
     # Default output file name is results.
     if args["--output"] is None:

--- a/trustymail/cli.py
+++ b/trustymail/cli.py
@@ -27,8 +27,10 @@ Options:
                               against.  For example, if you want to use 
                               Google's DNS then you would use the 
                               value --dns-hostnames='8.8.8.8,8.8.4.4'.  By 
-                              default the DNS configuration of the host OS are 
-                              used.
+                              default the DNS configuration of the host OS 
+                              (/etc/resolv.conf) is used.  Note that 
+                              the host's DNS configuration is not used at all 
+                              if this option is used.
 
 Notes:
    If no scan type options are specified, all are run against a given domain/input.

--- a/trustymail/cli.py
+++ b/trustymail/cli.py
@@ -42,8 +42,6 @@ import errno
 
 from trustymail import trustymail
 
-base_domains = {}
-
 # The default ports to be checked to see if an SMTP server is listening.
 _DEFAULT_SMTP_PORTS = {25, 465, 587}
 

--- a/trustymail/cli.py
+++ b/trustymail/cli.py
@@ -25,7 +25,7 @@ Options:
   --dns-hostnames=HOSTNAMES   A comma-delimited list of DNS servers to query 
                               against.  For example, if you want to use 
                               Google's DNS then you would use 
-                              the value --dns-hosts="8.8.8.8,8.8.4.4".  By 
+                              the value --dns-hostnames="8.8.8.8,8.8.4.4".  By 
                               default the DNS configuration of the host OS are 
                               used.
 

--- a/trustymail/domain.py
+++ b/trustymail/domain.py
@@ -81,7 +81,9 @@ class Domain:
 
     def add_mx_record(self, record):
         self.mx_records.append(record)
-        self.mail_servers.append(record[1])
+        # The rstrip is because dnspython's string representation of
+        # the record will contain a trailing period if it is a FQDN.
+        self.mail_servers.append(record.exchange.to_text().rstrip('.'))
 
     def parent_has_dmarc(self):
         if self.base_domain is None:

--- a/trustymail/domain.py
+++ b/trustymail/domain.py
@@ -9,16 +9,15 @@ class Domain:
 
     base_domains = {}
 
-    def __init__(self, domain_name):
-        self.domain_name = domain_name
+    def __init__(self, domain_name, timeout, smtp_timeout, smtp_localhost, smtp_ports, smtp_cache, dns_hostnames):
+        self.domain_name = domain_name.lower()
 
-        self.base_domain_name = public_list.get_public_suffix(domain_name)
+        self.base_domain_name = public_list.get_public_suffix(self.domain_name)
 
         if self.base_domain_name != self.domain_name:
             if self.base_domain_name not in Domain.base_domains:
-                domain = Domain(self.base_domain_name)
                 # Populate DMARC for parent.
-                trustymail.dmarc_scan(domain)
+                domain = trustymail.scan(self.base_domain_name, timeout, smtp_timeout, smtp_localhost, smtp_ports, smtp_cache, {"mx":False, "starttls":False, "spf":False, "dmarc":True}, dns_hostnames)
                 Domain.base_domains[self.base_domain_name] = domain
             self.base_domain = Domain.base_domains[self.base_domain_name]
         else:
@@ -83,7 +82,7 @@ class Domain:
         self.mx_records.append(record)
         # The rstrip is because dnspython's string representation of
         # the record will contain a trailing period if it is a FQDN.
-        self.mail_servers.append(record.exchange.to_text().rstrip('.'))
+        self.mail_servers.append(record.exchange.to_text().rstrip('.').lower())
 
     def parent_has_dmarc(self):
         if self.base_domain is None:

--- a/trustymail/domain.py
+++ b/trustymail/domain.py
@@ -144,7 +144,8 @@ class Domain:
             "DMARC Results on Base Domain": self.parent_dmarc_results(),
             "DMARC Policy": self.get_dmarc_policy(),
             
-            "Syntax Errors": self.format_list(self.syntax_errors)
+            "Syntax Errors": self.format_list(self.syntax_errors),
+            "Errors": self.format_list(self.errors)
             }
 
         return results

--- a/trustymail/trustymail.py
+++ b/trustymail/trustymail.py
@@ -20,7 +20,7 @@ CSV_HEADERS = [
     "DMARC Record", "Valid DMARC", "DMARC Results",
     "DMARC Record on Base Domain", "Valid DMARC Record on Base Domain",
     "DMARC Results on Base Domain", "DMARC Policy",
-    "Syntax Errors"
+    "Syntax Errors", "Errors"
 ]
 
 # A cache for SMTP scanning results

--- a/trustymail/trustymail.py
+++ b/trustymail/trustymail.py
@@ -200,10 +200,11 @@ def spf_scan(resolver, domain):
                 # (64.69.57.18) since it (1) has a valid PTR record and (2) is
                 # not listed by anyone as a valid mail server.
                 #
-                # I'm actually temporarily using an IP that www.google.com
-                # resolves to until we resolve why Google DNS does not return
-                # the same PTR records as the CAL DNS does for 64.69.57.18.
-                query = spf.query("172.217.13.228", "email_wizard@" + domain.domain_name, domain.domain_name, strict=2)
+                # I'm actually temporarily using an IP that
+                # virginia.edu resolves to until we resolve why Google
+                # DNS does not return the same PTR records as the CAL
+                # DNS does for 64.69.57.18.
+                query = spf.query("128.143.22.36", "email_wizard@" + domain.domain_name, domain.domain_name, strict=2)
                 response = query.check()
             except spf.AmbiguityWarning as error:
                 logging.debug("\t" + error.msg)

--- a/trustymail/trustymail.py
+++ b/trustymail/trustymail.py
@@ -226,8 +226,7 @@ def dmarc_scan(resolver, domain):
         for record in resolver.query(dmarc_domain, 'TXT'):
             record_text = record.to_text()
 
-            if record_text.startswith("\""):
-                record_text = record_text[1:-1]
+            record_text.lstrip('"')
 
             # Ensure the record is a DMARC record. Some domains that redirect will cause an SPF record to show.
             if record_text.startswith("v=DMARC1"):
@@ -258,7 +257,8 @@ def dmarc_scan(resolver, domain):
 
 
 def find_host_from_ip(ip_addr):
-    return str(resolver.query(reversename.from_address(ip_addr), "PTR")[0])
+    hostname, _ =  resolver.query(reversename.from_address(ip_addr), "PTR")
+    return str(hostname)
 
 
 def scan(domain_name, timeout, smtp_timeout, smtp_localhost, smtp_ports, smtp_cache, scan_types, dns_hostnames):

--- a/trustymail/trustymail.py
+++ b/trustymail/trustymail.py
@@ -224,9 +224,7 @@ def dmarc_scan(resolver, domain):
     try:
         dmarc_domain = '_dmarc.%s' % domain.domain_name
         for record in resolver.query(dmarc_domain, 'TXT'):
-            record_text = record.to_text()
-
-            record_text.lstrip('"')
+            record_text = record.to_text().strip('"')
 
             # Ensure the record is a DMARC record. Some domains that redirect will cause an SPF record to show.
             if record_text.startswith("v=DMARC1"):

--- a/trustymail/trustymail.py
+++ b/trustymail/trustymail.py
@@ -196,7 +196,14 @@ def spf_scan(resolver, domain):
                 result = "neutral"
 
             try:
-                query = spf.query("127.0.0.1", "email_wizard@" + domain.domain_name, domain.domain_name, strict=2)
+                # Here I am using the IP address for c1b1.ncats.cyber.dhs.gov
+                # (64.69.57.18) since it (1) has a valid PTR record and (2) is
+                # not listed by anyone as a valid mail server.
+                #
+                # I'm actually temporarily using an IP that www.google.com
+                # resolves to until we resolve why Google DNS does not return
+                # the same PTR records as the CAL DNS does for 64.69.57.18.
+                query = spf.query("172.217.13.228", "email_wizard@" + domain.domain_name, domain.domain_name, strict=2)
                 response = query.check()
             except spf.AmbiguityWarning as error:
                 logging.debug("\t" + error.msg)

--- a/trustymail/trustymail.py
+++ b/trustymail/trustymail.py
@@ -7,6 +7,7 @@ import datetime
 import json
 import socket
 
+import DNS
 import dns.resolver
 
 from trustymail.domain import Domain
@@ -268,6 +269,10 @@ def find_host_from_ip(ip_addr):
 
 
 def scan(domain_name, timeout, smtp_timeout, smtp_localhost, smtp_ports, smtp_cache, scan_types, dns_hostnames):
+    #
+    # Configure the dnspython library
+    #
+    
     # Set some timeouts
     dns.resolver.timeout = float(timeout)
     dns.resolver.lifetime = float(timeout)
@@ -280,6 +285,17 @@ def scan(domain_name, timeout, smtp_timeout, smtp_localhost, smtp_ports, smtp_ca
     # If the user passed in DNS hostnames to query against then use them
     if dns_hostnames:
         resolver.nameservers = dns_hostnames
+
+    #
+    # The spf library uses py3dns behind the scenes, so we need to configure
+    # that too
+    #
+    DNS.defaults['timeout'] = timeout
+    # Use TCP instead of UDP
+    DNS.defaults['protocol'] = 'tcp'
+    # If the user passed in DNS hostnames to query against then use them
+    if dns_hostnames:
+        DNS.defaults['server'] = dns_hostnames
 
     domain = Domain(domain_name)
 

--- a/trustymail/trustymail.py
+++ b/trustymail/trustymail.py
@@ -304,9 +304,11 @@ def scan(domain_name, timeout, smtp_timeout, smtp_localhost, smtp_ports, smtp_ca
     if dns_hostnames:
         DNS.defaults['server'] = dns_hostnames
 
-    domain = Domain(domain_name)
+    # Domain's constructor needs all these parameters because it does a DMARC
+    # scan in its init
+    domain = Domain(domain_name, timeout, smtp_timeout, smtp_localhost, smtp_ports, smtp_cache, dns_hostnames)
 
-    logging.debug("[{0}]".format(domain_name))
+    logging.debug("[{0}]".format(domain_name.lower()))
 
     if scan_types["mx"] and domain.is_live:
         mx_scan(resolver, domain)

--- a/trustymail/trustymail.py
+++ b/trustymail/trustymail.py
@@ -240,12 +240,13 @@ def dmarc_scan(resolver, domain):
         for record in resolver.query(dmarc_domain, 'TXT', tcp=True):
             record_text = record.to_text().strip('"')
 
-            # Ensure the record is a DMARC record. Some domains that redirect will cause an SPF record to show.
+            # Ensure the record is a DMARC record. Some domains that
+            # redirect will cause an SPF record to show.
             if record_text.startswith("v=DMARC1"):
                 domain.dmarc.append(record_text)
 
-            # Remove excess spacing
-            record_text = record_text.strip(" ")
+            # Remove excess whitespace
+            record_text = record_text.strip()
 
             # DMARC records follow a specific outline as to how they are defined - tag:value
             # We can split this up into a easily manipulatable
@@ -285,7 +286,10 @@ def scan(domain_name, timeout, smtp_timeout, smtp_localhost, smtp_ports, smtp_ca
     dns.resolver.lifetime = float(timeout)
     
     # Our resolver
-    resolver = dns.resolver.Resolver()
+    #
+    # Note that it uses the system configuration in /etc/resolv.conf
+    # if no DNS hostnames are specified.
+    resolver = dns.resolver.Resolver(configure=not dns_hostnames)
     # Retry queries if we receive a SERVFAIL response.  This may only indicate
     # a temporary network problem.
     resolver.retry_servfail = True


### PR DESCRIPTION
During testing we found that `trustymail` was not always idempotent. For example, two consecutive runs of `trustymail --debug --json --spf ed.gov` were observed to give different results.  It appears that the `py3dns` library does not always correctly handle the case where a DNS response is too big to fit in a UDP packet.  Further testing showed that the `dnspython` library was more reliable.

As a result, I changed `trustymail` to use `dnspython` instead of `py3dns`.  I also modified `requirements.txt` and `setup.py` to add the new requirement.

This should resolve #24.