### PR TITLE
If a domain is its own base domain, the base domain records will now be populated

### DIFF
--- a/trustymail/domain.py
+++ b/trustymail/domain.py
@@ -110,7 +110,7 @@ class Domain:
             if self.base_domain:
                 ans = self.base_domain.get_dmarc_policy()
             else:
-                ans = ''
+                ans = None
         return ans
 
     def generate_results(self):

--- a/trustymail/domain.py
+++ b/trustymail/domain.py
@@ -85,28 +85,33 @@ class Domain:
         self.mail_servers.append(record.exchange.to_text().rstrip('.').lower())
 
     def parent_has_dmarc(self):
-        if self.base_domain is None:
-            return None
-        return self.base_domain.has_dmarc()
+        ans = self.has_dmarc()
+        if self.base_domain:
+            ans = self.base_domain.has_dmarc()
+        return ans
 
     def parent_valid_dmarc(self):
-        if self.base_domain is None:
-            return None
-        return self.base_domain.valid_dmarc
+        ans = self.valid_dmarc
+        if self.base_domain:
+            return self.base_domain.valid_dmarc
+        return ans
 
     def parent_dmarc_results(self):
-        if self.base_domain is None:
-            return None
-        return self.format_list(self.base_domain.dmarc)
+        ans = self.format_list(self.dmarc)
+        if self.base_domain:
+            ans = self.format_list(self.base_domain.dmarc)
+        return ans
 
     def get_dmarc_policy(self):
-        # If the policy was never set, or isn't in the list of valid policies, check the parents.
-        if self.dmarc_policy is None or self.dmarc_policy.lower() not in ['quarantine', 'reject', 'none']:
-            if self.base_domain is None:
-                return ''
+        ans = self.dmarc_policy
+        # If the policy was never set, or isn't in the list of valid
+        # policies, check the parents.
+        if ans is None or ans.lower() not in ['quarantine', 'reject', 'none']:
+            if self.base_domain:
+                ans = self.base_domain.get_dmarc_policy()
             else:
-                return self.base_domain.get_dmarc_policy()
-        return self.dmarc_policy
+                ans = ''
+        return ans
 
     def generate_results(self):
         mail_servers_that_support_smtp = [x for x in self.starttls_results.keys() if self.starttls_results[x]['supports_smtp']]


### PR DESCRIPTION
For example:
```
$ trustymail --json --dns=8.8.8.8 --dmarc gsa.gov
[
  {
    "Base Domain": "gsa.gov",
    "DMARC Policy": "none",
    "DMARC Record": true,
    "DMARC Record on Base Domain": true,
    "DMARC Results": "v=DMARC1; p=none; rua=mailto:dmarcreports@gsa.gov; sp=none; pct=10; ri=86400",
    "DMARC Results on Base Domain": "v=DMARC1; p=none; rua=mailto:dmarcreports@gsa.gov; sp=none; pct=10; ri=86400",
    "Debug Info": null,
    "Domain": "gsa.gov",
    "Domain Supports SMTP": false,
    "Domain Supports SMTP Results": null,
    "Domain Supports STARTTLS": false,
    "Domain Supports STARTTLS Results": null,
    "Live": true,
    "MX Record": false,
    "Mail Server Ports Tested": null,
    "Mail Servers": null,
    "SPF Record": false,
    "SPF Results": null,
    "Syntax Errors": null,
    "Valid DMARC": true,
    "Valid DMARC Record on Base Domain": true,
    "Valid SPF": false
  }
]
```

If a domain is NOT its own base domain then the base domain records will be populated as before.  For example:
```
$ trustymail --json --dns=8.8.8.8 --dmarc mail.google.com
[
  {
    "Base Domain": "google.com",
    "DMARC Policy": "reject",
    "DMARC Record": false,
    "DMARC Record on Base Domain": true,
    "DMARC Results": null,
    "DMARC Results on Base Domain": "v=DMARC1; p=reject; rua=mailto:mailauth-reports@google.com",
    "Debug Info": "[DMARC] In dmarc_scan at /home/jeremy_frasier/dhs-ncats/trustymail/trustymail/trustymail.py:339: None of DNS query names exist: _dmarc.mail.google.com., _dmarc.mail.google.com.",
    "Domain": "mail.google.com",
    "Domain Supports SMTP": false,
    "Domain Supports SMTP Results": null,
    "Domain Supports STARTTLS": false,
    "Domain Supports STARTTLS Results": null,
    "Live": true,
    "MX Record": false,
    "Mail Server Ports Tested": null,
    "Mail Servers": null,
    "SPF Record": false,
    "SPF Results": null,
    "Syntax Errors": null,
    "Valid DMARC": false,
    "Valid DMARC Record on Base Domain": true,
    "Valid SPF": false
  }
]
```

This resolves #31.