### PR TITLE
Fixed a bug

### DIFF
--- a/trustymail/domain.py
+++ b/trustymail/domain.py
@@ -116,7 +116,7 @@ class Domain:
     def generate_results(self):
         mail_servers_that_support_smtp = [x for x in self.starttls_results.keys() if self.starttls_results[x]['supports_smtp']]
         mail_servers_that_support_starttls = [x for x in self.starttls_results.keys() if self.starttls_results[x]['starttls']]
-        domain_supports_smtp = bool(mail_servers_that_support_starttls)
+        domain_supports_smtp = bool(mail_servers_that_support_smtp)
 
         results = {
             'Domain': self.domain_name,


### PR DESCRIPTION
A domain supports SMTP if any mail server supports SMTP, but I used `mail_servers_that_support_starttls` instead due to a typo.

Thanks to @dav3r for spotting this!