### PR TITLE
Check the base/organizational domains of DMARC reporting URLs - not the full domain

### DIFF
--- a/trustymail/__init__.py
+++ b/trustymail/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import unicode_literals, absolute_import, print_function
 
-__version__ = '0.5.2-dev'
+__version__ = '0.5.3-dev'

--- a/trustymail/domain.py
+++ b/trustymail/domain.py
@@ -37,7 +37,11 @@ def get_psl():
     return psl
 
 
-public_list = get_psl()
+def get_public_suffix(domain):
+    """Returns the public suffix of a given domain"""
+    public_list = get_psl()
+
+    return public_list.get_public_suffix(domain)
 
 
 def format_list(record_list):
@@ -58,7 +62,7 @@ class Domain:
     def __init__(self, domain_name, timeout, smtp_timeout, smtp_localhost, smtp_ports, smtp_cache, dns_hostnames):
         self.domain_name = domain_name.lower()
 
-        self.base_domain_name = public_list.get_public_suffix(self.domain_name)
+        self.base_domain_name = get_public_suffix(self.domain_name)
 
         if self.base_domain_name != self.domain_name:
             if self.base_domain_name not in Domain.base_domains:

--- a/trustymail/trustymail.py
+++ b/trustymail/trustymail.py
@@ -474,7 +474,10 @@ def dmarc_scan(resolver, domain):
                                 domain.dmarc_forensic_uris.append(uri)
                             email_address = parsed_uri["address"]
                             email_domain = email_address.split('@')[-1]
-                            if get_public_suffix(email_domain).lower() != domain.base_domain.lower():
+                            # Domain.domain_name is set to lowercase in
+                            # Donain's constructor, so there is no need to call
+                            # lower() on the right-hand side of the comparison
+                            if get_public_suffix(email_domain).lower() != domain.base_domain.domain_name:
                                 target = '{0}._report._dmarc.{1}'.format(domain.domain_name, email_domain)
                                 error_message = '{0} does not indicate that it accepts DMARC reports about {1} - ' \
                                                 'https://tools.ietf.org' \

--- a/trustymail/trustymail.py
+++ b/trustymail/trustymail.py
@@ -14,7 +14,7 @@ import DNS
 import dns.resolver
 import dns.reversename
 
-from trustymail.domain import Domain
+from trustymail.domain import get_public_suffix, Domain
 
 # A cache for SMTP scanning results
 _SMTP_CACHE = {}
@@ -474,7 +474,7 @@ def dmarc_scan(resolver, domain):
                                 domain.dmarc_forensic_uris.append(uri)
                             email_address = parsed_uri["address"]
                             email_domain = email_address.split('@')[-1]
-                            if email_domain.lower() != domain.domain_name.lower():
+                            if get_public_suffix(email_domain).lower() != domain.base_domain.lower():
                                 target = '{0}._report._dmarc.{1}'.format(domain.domain_name, email_domain)
                                 error_message = '{0} does not indicate that it accepts DMARC reports about {1} - ' \
                                                 'https://tools.ietf.org' \

--- a/trustymail/trustymail.py
+++ b/trustymail/trustymail.py
@@ -474,10 +474,7 @@ def dmarc_scan(resolver, domain):
                                 domain.dmarc_forensic_uris.append(uri)
                             email_address = parsed_uri["address"]
                             email_domain = email_address.split('@')[-1]
-                            # Domain.domain_name is set to lowercase in
-                            # Donain's constructor, so there is no need to call
-                            # lower() on the right-hand side of the comparison
-                            if get_public_suffix(email_domain).lower() != domain.base_domain.domain_name:
+                            if get_public_suffix(email_domain).lower() != domain.base_domain_name.lower():
                                 target = '{0}._report._dmarc.{1}'.format(domain.domain_name, email_domain)
                                 error_message = '{0} does not indicate that it accepts DMARC reports about {1} - ' \
                                                 'https://tools.ietf.org' \


### PR DESCRIPTION
It was pointed out to me in an upstream issue that only the base domain has to match for reporting URIs

https://github.com/domainaware/checkdmarc/issues/21

This PR fixes the upstream mistake