### PR TITLE
Make pct < 100 valid

### DIFF
--- a/trustymail/trustymail.py
+++ b/trustymail/trustymail.py
@@ -452,7 +452,7 @@ def dmarc_scan(resolver, domain):
                             domain.valid_dmarc = False
                         domain.dmarc_pct = pct
                         if pct < 100:
-                            handle_syntax_error('[DMARC]', domain, 'Error: The DMARC pct tag value may be less than 100 (the implicit default) during deployment, but should be removed or set to 100 upon full deployment')
+                            handle_syntax_error('[DMARC]', domain, 'Warning: The DMARC pct tag value may be less than 100 (the implicit default) during deployment, but should be removed or set to 100 upon full deployment')
                     except ValueError:
                         msg = 'invalid DMARC pct tag value: {0} - must be an integer'.format(tag_dict[tag])
                         handle_syntax_error('[DMARC]', domain, '{0}'.format(msg))

--- a/trustymail/trustymail.py
+++ b/trustymail/trustymail.py
@@ -452,8 +452,7 @@ def dmarc_scan(resolver, domain):
                             domain.valid_dmarc = False
                         domain.dmarc_pct = pct
                         if pct < 100:
-                            handle_syntax_error('[DMARC]', domain, 'Error: The DMARC pct tag value must not be less than 100 (the implicit default), so that the policy applies to all mail')
-                            domain.valid_dmarc = False
+                            handle_syntax_error('[DMARC]', domain, 'Error: The DMARC pct tag value may be less than 100 (the implicit default) during deployment, but should be removed or set to 100 upon full deployment')
                     except ValueError:
                         msg = 'invalid DMARC pct tag value: {0} - must be an integer'.format(tag_dict[tag])
                         handle_syntax_error('[DMARC]', domain, '{0}'.format(msg))


### PR DESCRIPTION
This small change un-invalidates the use of pct flags that are < 100. 

While it is true that the intent of BOD 18-01 is to get organizations to either leave the implicit value of 100 or set it directly, I'm wary of calling this syntactically invalid. For our purposes, we can check the value of `DMARC Policy Percentage` and relay good info back to agencies.

cc: @boberlas, https://github.com/dhs-ncats/cyber.dhs.gov/issues/29