### PR TITLE
Some DMARC fields not populated

### DIFF
--- a/trustymail/domain.py
+++ b/trustymail/domain.py
@@ -188,7 +188,7 @@ class Domain:
 
     def get_dmarc_pct(self):
         ans = self.dmarc_pct
-        if not ans:
+        if not ans and self.base_domain:
             # Check the parents
             ans = self.base_domain.get_dmarc_pct()
         return ans

--- a/trustymail/trustymail.py
+++ b/trustymail/trustymail.py
@@ -418,6 +418,8 @@ def dmarc_scan(resolver, domain):
                         msg = 'Unknown DMARC subdomain policy {0}'.format(tag_dict[tag])
                         handle_syntax_error('[DMARC]', domain, '{0}'.format(msg))
                         domain.valid_dmarc = False
+                    else:
+                        domain.dmarc_subdomain_policy = tag_dict[tag]
                 elif tag == 'fo':
                     values = tag_dict[tag].split(':')
                     if '0' in values and '1' in values:


### PR DESCRIPTION
I noticed that some of the `trustymail` output fields are unpopulated when they really should be. For example, DMARC fields like percentage, ruas, rufs, etc. are only populated if the domain itself has a DMARC record. They are not populated if the DMARC configuration is inherited from the base domain.

I also added some code to take into account `sp=` when adjudicating `dmarc_policy`.