### PR TITLE
Fixed a bug where domains were incorrectly being flagged as "not live"

### DIFF
--- a/trustymail/trustymail.py
+++ b/trustymail/trustymail.py
@@ -508,13 +508,13 @@ def dmarc_scan(resolver, domain):
 
         domain.dmarc_has_aggregate_uri = len(domain.dmarc_aggregate_uris) > 0
         domain.dmarc_has_forensic_uri = len(domain.dmarc_forensic_uris) > 0
-    except (dns.resolver.NoNameservers, dns.resolver.NXDOMAIN) as error:
+    except dns.resolver.NoNameservers as error:
         # The NoNameservers exception means that we got a SERVFAIL response.
         # These responses are almost always permanent, not temporary, so let's
         # treat the domain as not live.
         domain.is_live = False
         handle_error('[DMARC]', domain, error)
-    except (dns.resolver.NoAnswer, dns.exception.Timeout) as error:
+    except (dns.resolver.NXDOMAIN, dns.resolver.NoAnswer, dns.exception.Timeout) as error:
         handle_error('[DMARC]', domain, error)
 
 


### PR DESCRIPTION
Dave Redmin noticed that a lot of domains were being incorrectly flagged as "not live".  The problem turned out to that domains are being flagged as "not live" when a lookup of the DMARC record returns
NXDOMAIN.  This is incorrect, since `domain.com` may well exist even when `_dmarc.domain.com` does not.