### PR TITLE
Fixing a bug with public suffix list caching

### DIFF
--- a/scripts/trustymail
+++ b/scripts/trustymail
@@ -4,7 +4,7 @@
 """trustymail: A tool for scanning DNS mail records for evaluating security.
 Usage:
   trustymail (INPUT ...) [options]
-  trustymail (INPUT ...) [--output=OUTFILE] [--timeout=TIMEOUT] [--smtp-timeout=TIMEOUT] [--smtp-localhost=HOSTNAME] [--smtp-ports=PORTS] [--no-smtp-cache] [--mx] [--starttls] [--spf] [--dmarc] [--debug] [--json] [--dns=HOSTNAMES]
+  trustymail (INPUT ...) [--output=OUTFILE] [--timeout=TIMEOUT] [--smtp-timeout=TIMEOUT] [--smtp-localhost=HOSTNAME] [--smtp-ports=PORTS] [--no-smtp-cache] [--mx] [--starttls] [--spf] [--dmarc] [--debug] [--json] [--dns=HOSTNAMES] [--psl-filename=FILENAME]
   trustymail (-h | --help)
 
 Options:
@@ -34,6 +34,10 @@ Options:
                               (/etc/resolv.conf) is used.  Note that
                               the host's DNS configuration is not used at all
                               if this option is used.
+  --psl-filename=FILENAME     The name of the file where the public suffix list
+                              cache will be saved.  If set to the name of an
+                              existing file then that file will be used as the
+                              PSL.
 
 Notes:
    If no scan type options are specified, all are run against a given domain/input.
@@ -47,15 +51,19 @@ import os
 import docopt
 
 # Local imports
-from trustymail import __version__
-from trustymail import trustymail
+import trustymail
 
 # The default ports to be checked to see if an SMTP server is listening.
 _DEFAULT_SMTP_PORTS = {25, 465, 587}
 
 
 def main():
-    args = docopt.docopt(__doc__, version=__version__)
+    args = docopt.docopt(__doc__, version=trustymail.__version__)
+
+    # Monkey patching trustymail to make it cache the PSL where we want
+    if args['--psl-filename'] is not None:
+        trustymail.PublicSuffixListFilename = args['--psl-filename']
+    import trustymail.trustymail as tmail
 
     log_level = logging.WARN
     if args['--debug']:
@@ -107,10 +115,10 @@ def main():
 
     domain_scans = []
     for domain_name in domains:
-        domain_scans.append(trustymail.scan(domain_name, timeout,
-                                            smtp_timeout, smtp_localhost,
-                                            smtp_ports, not args['--no-smtp-cache'],
-                                            scan_types, dns_hostnames))
+        domain_scans.append(tmail.scan(domain_name, timeout,
+                                       smtp_timeout, smtp_localhost,
+                                       smtp_ports, not args['--no-smtp-cache'],
+                                       scan_types, dns_hostnames))
 
     # Default output file name is results.
     if args['--output'] is None:
@@ -125,14 +133,14 @@ def main():
         output_file_name += '.csv'
 
     if args['--json']:
-        json_out = trustymail.generate_json(domain_scans)
+        json_out = tmail.generate_json(domain_scans)
         if args['--output'] is None:
             print(json_out)
         else:
             write(json_out, output_file_name)
             logging.warn('Wrote results to %s.' % output_file_name)
     else:
-        trustymail.generate_csv(domain_scans, output_file_name)
+        tmail.generate_csv(domain_scans, output_file_name)
 
 
 def write(content, out_file):

--- a/trustymail/__init__.py
+++ b/trustymail/__init__.py
@@ -1,3 +1,5 @@
 from __future__ import unicode_literals, absolute_import, print_function
 
 __version__ = '0.5.4-dev'
+
+PublicSuffixListFilename = 'public_suffix_list.dat'

--- a/trustymail/domain.py
+++ b/trustymail/domain.py
@@ -1,9 +1,11 @@
-from os import path, stat
 from datetime import datetime, timedelta
 from collections import OrderedDict
+import logging
+from os import path, stat
 
 import publicsuffix
 
+from trustymail import PublicSuffixListFilename
 from trustymail import trustymail
 
 
@@ -15,24 +17,22 @@ def get_psl():
     -------
     PublicSuffixList: An instance of PublicSuffixList loaded with a cached or updated list
     """
-    psl_path = 'public_suffix_list.dat'
 
     def download_psl():
         fresh_psl = publicsuffix.fetch()
-        with open(psl_path, 'w', encoding='utf-8') as fresh_psl_file:
+        with open(PublicSuffixListFilename, 'w', encoding='utf-8') as fresh_psl_file:
             fresh_psl_file.write(fresh_psl.read())
 
-        return publicsuffix.PublicSuffixList(fresh_psl)
-
-    if not path.exists(psl_path):
-        psl = download_psl()
+    # Download the psl if necessary
+    if not path.exists(PublicSuffixListFilename):
+        download_psl()
     else:
-        psl_age = datetime.now() - datetime.fromtimestamp(stat(psl_path).st_mtime)
+        psl_age = datetime.now() - datetime.fromtimestamp(stat(PublicSuffixListFilename).st_mtime)
         if psl_age > timedelta(hours=24):
-            psl = download_psl()
-        else:
-            with open(psl_path, encoding='utf-8') as psl_file:
-                psl = publicsuffix.PublicSuffixList(psl_file)
+            download_psl()
+
+    with open(PublicSuffixListFilename, encoding='utf-8') as psl_file:
+        psl = publicsuffix.PublicSuffixList(psl_file)
 
     return psl
 

--- a/trustymail/domain.py
+++ b/trustymail/domain.py
@@ -1,6 +1,5 @@
 from datetime import datetime, timedelta
 from collections import OrderedDict
-import logging
 from os import path, stat
 
 import publicsuffix


### PR DESCRIPTION
Starting with no `public_suffix_list.dat` cache file and _without_ this fix (using the current `develop` branch):
```
$ trustymail --debug --json --smtp-ports=25 --dns=8.8.8.8 dhs.gov
2018-03-16 18:07:09,133 [gov]
2018-03-16 18:07:09,269 [DMARC] In dmarc_scan at /home/jeremy_frasier/dhs-ncats/trustymail/trustymail/trustymail.py:522: None of DNS query names exist: _dmarc.gov., _dmarc.gov.
<snip>
2018-03-16 18:07:14,087 [DMARC] In handle_syntax_error at /home/jeremy_frasier/dhs-ncats/trustymail/trustymail/trustymail.py:656: hq.dhs.gov does not indicate that it accepts DMARC reports about dhs.gov - https://tools.ietf.org/html/rfc7489#section-7.1
[
  {
    "Domain": "dhs.gov",
    "Base Domain": "gov",
<snip>
    "Valid DMARC": false,
    "DMARC Results": "v=DMARC1; p=none; pct=100; rua=mailto:DMARC@hq.dhs.gov, mailto:reports@dmarc.cyber.dhs.gov",
    "DMARC Record on Base Domain": false,
    "Valid DMARC Record on Base Domain": false,
    "DMARC Results on Base Domain": null,
<snip>
    "Syntax Errors": "[DMARC] In handle_syntax_error at /home/jeremy_frasier/dhs-ncats/trustymail/trustymail/trustymail.py:656: hq.dhs.gov does not indicate that it accepts DMARC reports about dhs.gov - https://tools.ietf.org/html/rfc7489#section-7.1",
    "Debug Info": null
  }
]
```

Starting with no `public_suffix_list.dat` cache file and _with_ this fix (using the current `bugfix/problem_with_psl_caching` branch):
```
$ trustymail --debug --json --smtp-ports=25 --dns=8.8.8.8 dhs.gov
2018-03-17 07:36:37,046 [dhs.gov]
<snip>
[
  {
    "Domain": "dhs.gov",
    "Base Domain": "dhs.gov",
<snip>
    "Valid DMARC": true,
    "DMARC Results": "v=DMARC1; p=none; pct=100; rua=mailto:DMARC@hq.dhs.gov, mailto:reports@dmarc.cyber.dhs.gov",
    "DMARC Record on Base Domain": true,
    "Valid DMARC Record on Base Domain": true,
    "DMARC Results on Base Domain": "v=DMARC1; p=none; pct=100; rua=mailto:DMARC@hq.dhs.gov, mailto:reports@dmarc.cyber.dhs.gov",
<snip>
    "Syntax Errors": null,
    "Debug Info": null
  }
]
```

Note that running the old (`develop`) code you gives the same result obtained when running the new (`bugfix/problem_with_psl_caching`) code the first time.

One can also specify where the PSL will be cached using the `--psl-filename` command-line option.