### PR TITLE
Some domains are listed as live even when DNS times out

### DIFF
--- a/trustymail/__init__.py
+++ b/trustymail/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals, absolute_import, print_function
 
-__version__ = '0.6.0'
+__version__ = '0.6.1'
 
 PublicSuffixListFilename = 'public_suffix_list.dat'
 PublicSuffixListReadOnly = False

--- a/trustymail/trustymail.py
+++ b/trustymail/trustymail.py
@@ -59,13 +59,12 @@ def mx_scan(resolver, domain):
         # records more than whether their records fit in a single UDP packet.
         for record in resolver.query(domain.domain_name, 'MX', tcp=True):
             domain.add_mx_record(record)
-    except (dns.resolver.NoNameservers, dns.resolver.NXDOMAIN) as error:
+    except (dns.resolver.NoNameservers, dns.resolver.NXDOMAIN,
+            dns.resolver.NoAnswer, dns.exception.Timeout) as error:
         # The NoNameServers exception means that we got a SERVFAIL response.
         # These responses are almost always permanent, not temporary, so let's
-        # treat the domain as not live.
+        # treat the domain as not live if we get one of those.
         domain.is_live = False
-        handle_error('[MX]', domain, error)
-    except (dns.resolver.NoAnswer, dns.exception.Timeout) as error:
         handle_error('[MX]', domain, error)
 
 


### PR DESCRIPTION
@climber-girl noticed that the output of the following command reports `nara-at-home.gov` as "live" even though there are no MX records for that domain:
```
$ trustymail --json --debug --timeout=30 --smtp-timeout=5 --dns=8.8.4.4 nara-at-work.gov
```

This pull request fixes this issue.  Domains for which no MX records exist will no longer be listed as "live".  

This pull request is related to NCATS JIRA ticket CYHY-706.