### PR TITLE
Getting a SERVFAIL when checking for DMARC DNS record does not mean the domain is not live

### DIFF
--- a/trustymail/__init__.py
+++ b/trustymail/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals, absolute_import, print_function
 
-__version__ = '0.6.1'
+__version__ = '0.6.2'
 
 PublicSuffixListFilename = 'public_suffix_list.dat'
 PublicSuffixListReadOnly = False

--- a/trustymail/trustymail.py
+++ b/trustymail/trustymail.py
@@ -520,6 +520,11 @@ def dmarc_scan(resolver, domain):
         domain.dmarc_has_forensic_uri = len(domain.dmarc_forensic_uris) > 0
     except (dns.resolver.NoNameservers, dns.resolver.NXDOMAIN,
             dns.resolver.NoAnswer, dns.exception.Timeout) as error:
+        # Normally we count a NoNameservers exception as indicating
+        # that a domain is "not live".  In this case we don't, though,
+        # since the DMARC DNS check doesn't query for the domain name
+        # itself.  If the domain name is domain.com, the DMARC DNS
+        # check queries for _dmarc.domain.com.
         handle_error('[DMARC]', domain, error)
 
 

--- a/trustymail/trustymail.py
+++ b/trustymail/trustymail.py
@@ -251,7 +251,7 @@ def get_spf_record_text(resolver, domain_name, domain, follow_redirect=False):
                 # Not an spf record, ignore it.
                 continue
 
-            match = re.search('v=spf1\s*redirect=(\S*)', record_text)
+            match = re.search(r'v=spf1\s*redirect=(\S*)', record_text)
             if follow_redirect and match:
                 redirect_domain_name = match.group(1)
                 record_to_return = get_spf_record_text(resolver, redirect_domain_name, domain)

--- a/trustymail/trustymail.py
+++ b/trustymail/trustymail.py
@@ -518,13 +518,8 @@ def dmarc_scan(resolver, domain):
 
         domain.dmarc_has_aggregate_uri = len(domain.dmarc_aggregate_uris) > 0
         domain.dmarc_has_forensic_uri = len(domain.dmarc_forensic_uris) > 0
-    except dns.resolver.NoNameservers as error:
-        # The NoNameservers exception means that we got a SERVFAIL response.
-        # These responses are almost always permanent, not temporary, so let's
-        # treat the domain as not live.
-        domain.is_live = False
-        handle_error('[DMARC]', domain, error)
-    except (dns.resolver.NXDOMAIN, dns.resolver.NoAnswer, dns.exception.Timeout) as error:
+    except (dns.resolver.NoNameservers, dns.resolver.NXDOMAIN,
+            dns.resolver.NoAnswer, dns.exception.Timeout) as error:
         handle_error('[DMARC]', domain, error)
 
 

--- a/trustymail/trustymail.py
+++ b/trustymail/trustymail.py
@@ -312,8 +312,8 @@ def parse_dmarc_report_uri(uri):
     """
     Parses a DMARC Reporting (i.e. ``rua``/``ruf)`` URI
 
-   Notes
-   -----
+    Notes
+    -----
         ``mailto:`` is the only reporting URI supported in `DMARC1`
 
     Arguments


### PR DESCRIPTION
This resolves NCATS JIRA ticket OPS-3064, as reported by @climber-girl.