### PR TITLE
Do not treat ambiguity as error

### DIFF
--- a/trustymail/__init__.py
+++ b/trustymail/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals, absolute_import, print_function
 
-__version__ = '0.6.2'
+__version__ = '0.6.3'
 
 PublicSuffixListFilename = 'public_suffix_list.dat'
 PublicSuffixListReadOnly = False


### PR DESCRIPTION
Digging through the code of the SPF library we're using in `trustymail` (which was written by an author of the SPF RFC), I can confirm the following:
* The exception class that results in ambiguous being returned is called `AmbiguityWarning` (i.e. not `AmbiguityError`).
* `AmbiguityWarning` is raised if `strict == 2` (the highest setting) and we receive a truncated UDP reply.  (This doesn't apply to `trustymail` since we use TCP for our DNS queries to avoid this.)
* `AmbiguityWarning` is raised if `strict == 2` (the highest setting) and the obsolete `default` modifier is used.
* `AmbiguityWarning` is raised if `strict == 2` (the highest setting), both `TXT` and `SPF` (type 99) DNS records are present, and they do not agree.
* `AmbiguityWarning` is raised if `strict == 2` (the highest setting), the `mx` mechanism is used, and there are no `MX` records present.
* `AmbiguityWarning` is raised if `strict == 2` (the highest setting), the `a` mechanism is used, and there are no `A` records present.
* `AmbiguityWarning` is raised if `strict == 2` (the highest setting), the `ptr` mechanism is used, and there are no `PTR` records present.
* `AmbiguityWarning` is raised if `strict == 2` (the highest setting), and there is a `CNAME` loop.

We have been treating these conditions as SPF errors, but it makes more sense to treat them as warnings.  Therefore I modified the code so that it logs these conditions as warnings (so that they will appear in the CSV that is attached to the report) but does not label the SPF as "invalid" in response.

`treas.gov` is one host that was being incorrectly labeled as having invalid SPF, since is uses the `mx` mechanism but does not have any `MX` records.