### PR TITLE
Do not look up the SPF record twice

### DIFF
--- a/trustymail/__init__.py
+++ b/trustymail/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals, absolute_import, print_function
 
-__version__ = '0.6.3'
+__version__ = '0.6.4'
 
 PublicSuffixListFilename = 'public_suffix_list.dat'
 PublicSuffixListReadOnly = False

--- a/trustymail/trustymail.py
+++ b/trustymail/trustymail.py
@@ -204,7 +204,7 @@ def check_spf_record(record_text, expected_result, domain, strict=2):
         query = spf.query('128.143.22.36',
                           'email_wizard@' + domain.domain_name,
                           domain.domain_name, strict=strict)
-        response = query.check()
+        response = query.check(spf=record_text)
 
         response_type = response[0]
         if response_type == 'temperror' or response_type == 'permerror':
@@ -325,7 +325,7 @@ def spf_scan(resolver, domain):
         else:
             result = 'neutral'
 
-        check_spf_record(record_text_not_following_redirect, result, domain)
+        check_spf_record(record_text_following_redirect, result, domain)
 
 
 def parse_dmarc_report_uri(uri):


### PR DESCRIPTION
I suspect that these repeated DNS queries may be occasionally failing, and that is what is responsible for the "Result unexpectedly differs" errors that are seen in the `trustymail` results.  (See NCATS JIRA ticket OPS-3133 for more details on this.)

In my latest scan with the old code, 34 out of the approximately 80,000 hosts scanned suffered from this error.  Scanning with the new code I see this error only four times, but in all four cases the error is due to an invalid SPF record.