### PR TITLE
DOE fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.xlsx
 *.csv
 todo.txt
 *.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ COPY . .
 RUN pip install --no-cache-dir .
 
 ENTRYPOINT ["trustymail"]
-
+CMD ["--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3
+
+WORKDIR /app
+
+COPY . .
+RUN pip install --no-cache-dir .
+
+ENTRYPOINT ["trustymail"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,13 @@ FROM python:3
 
 WORKDIR /app
 
+COPY requirements.txt requirements.txt
+
+RUN pip install --no-cache-dir -r requirements.txt
+
 COPY . .
-RUN pip install --no-cache-dir .
+
+RUN pip install --editable .
 
 ENTRYPOINT ["trustymail"]
 CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ Then run the CLI:
 python scripts/trustymail [options] example.com
 ```
 
+### Using Docker (optional)
+
+```bash
+./run [opts]
+```
+
+`opts` are the same arguments that would get passed to `trustymail`.
+
 ### Usage and examples ###
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -61,29 +61,29 @@ output will always be written to disk, defaulting to `results.csv`.
   -h --help                   Show this message.
   -o --output=OUTFILE         Name of output file. (Default results)
   -t --timeout=TIMEOUT        The DNS lookup timeout in seconds. (Default is 5.)
-  --smtp-timeout=TIMEOUT      The SMTP connection timeout in seconds. (Default 
+  --smtp-timeout=TIMEOUT      The SMTP connection timeout in seconds. (Default
                               is 5.)
-  --smtp-localhost=HOSTNAME   The hostname to use when connecting to SMTP 
+  --smtp-localhost=HOSTNAME   The hostname to use when connecting to SMTP
                               servers.  (Default is the FQDN of the host from
                               which trustymail is being run.)
-  --smtp-ports=PORTS          A comma-delimited list of ports at which to look 
+  --smtp-ports=PORTS          A comma-delimited list of ports at which to look
                               for SMTP servers.  (Default is '25,465,587'.)
-  --no-smtp-cache             Do not cache SMTP results during the run.  This 
-                              may results in slower scans due to testing the 
+  --no-smtp-cache             Do not cache SMTP results during the run.  This
+                              may results in slower scans due to testing the
                               same mail servers multiple times.
   --mx                        Only check mx records
-  --starttls                  Only check mx records and STARTTLS support. 
+  --starttls                  Only check mx records and STARTTLS support.
                               (Implies --mx.)
   --spf                       Only check spf records
   --dmarc                     Only check dmarc records
   --debug                     Output should include error messages.
-  --dns=HOSTNAMES             A comma-delimited list of DNS servers to query 
-                              against.  For example, if you want to use 
-                              Google's DNS then you would use the 
-                              value --dns-hostnames='8.8.8.8,8.8.4.4'.  By 
-                              default the DNS configuration of the host OS 
-                              (/etc/resolv.conf) is used.  Note that 
-                              the host's DNS configuration is not used at all 
+  --dns=HOSTNAMES             A comma-delimited list of DNS servers to query
+                              against.  For example, if you want to use
+                              Google's DNS then you would use the
+                              value --dns-hostnames='8.8.8.8,8.8.4.4'.  By
+                              default the DNS configuration of the host OS
+                              (/etc/resolv.conf) is used.  Note that
+                              the host's DNS configuration is not used at all
                               if this option is used.
   --psl-filename=FILENAME     The name of the file where the public suffix list
                               (PSL) cache will be saved.  If set to the name of
@@ -91,8 +91,8 @@ output will always be written to disk, defaulting to `results.csv`.
                               the PSL.  If not present then the PSL cache will
                               be saved to a file in the current directory called
                               public_suffix_list.dat.
-  --psl-read-only             If present, then the public suffix list (PSL) 
-                              cache will be read but never overwritten.  This 
+  --psl-read-only             If present, then the public suffix list (PSL)
+                              cache will be read but never overwritten.  This
                               is useful when running in AWS Lambda, for
                               instance, where the local filesystem is read-only.
 ```
@@ -160,7 +160,7 @@ The following values are returned in `results.csv`:
 * `DMARC Aggregate Report URIs` - A list of the DMARC aggregate report
   URIs specified by the domain.
 * `DMARC Forensic Report URIs` - A list of the DMARC forensic report
-  URIs specified by the domain. 
+  URIs specified by the domain.
 * `DMARC Has Aggregate Report URI` - A boolean value that indicates if
   `DMARC Results` included `rua` URIs that tell recipients where to
   send DMARC aggregate reports.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,7 @@
+-r requirements.txt
+
+check-manifest>=0.36
+pytest>=3.5.0
+semver>=2.7.9
+tox>=3.0.0
+wheel>=0.31.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,6 @@
--e .[dev]
+dnspython>=1.15.0
+docopt>=0.6.2
+publicsuffix>=1.1.0
+py3dns>=3.1.0
+pyspf==2.0.11
+requests>=2.18.4

--- a/run
+++ b/run
@@ -7,5 +7,5 @@ docker build -t trustymail/cli .
 
 docker run --rm -it \
   --name trustymail \
-  -v $(pwd):/home/trustymail \
+  -v $(pwd):/app \
   trustymail/cli $@

--- a/run
+++ b/run
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+set -x
+
+docker build -t trustymail/cli .
+
+docker run --rm -it \
+  --name trustymail \
+  -v $(pwd):/home/trustymail \
+  trustymail/cli $@

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,14 @@ def readme():
         return f.read()
 
 
+with open('requirements.txt') as fp:
+    reqs = [line.strip() for line in fp.readlines() if line]
+
+with open('requirements-dev.txt') as fp:
+    lines = [line.strip() for line in fp.readlines() if line]
+    dev_reqs = [line for line in lines if line and '-r requirements.txt' not in line]
+
+
 setup(
     name='trustymail',
     version=__version__,
@@ -61,23 +69,10 @@ setup(
 
     packages=['trustymail'],
 
-    install_requires=[
-        'dnspython>=1.15.0',
-        'docopt>=0.6.2',
-        'publicsuffix>=1.1.0',
-        'py3dns>=3.1.0',
-        'pyspf==2.0.11',
-        'requests>=2.18.4'
-    ],
+    install_requires=reqs,
 
     extras_require={
-        'dev': [
-            'check-manifest>=0.36',
-            'pytest>=3.5.0',
-            'semver>=2.7.9',
-            'tox>=3.0.0',
-            'wheel>=0.31.0'
-        ],
+        'dev': dev_reqs,
     },
 
     scripts=['scripts/trustymail']

--- a/trustymail/__init__.py
+++ b/trustymail/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals, absolute_import, print_function
 
-__version__ = '0.6.4'
+__version__ = '0.6.5-dev'
 
 PublicSuffixListFilename = 'public_suffix_list.dat'
 PublicSuffixListReadOnly = False

--- a/trustymail/__init__.py
+++ b/trustymail/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals, absolute_import, print_function
 
-__version__ = '0.6.5-dev'
+__version__ = '0.6.5'
 
 PublicSuffixListFilename = 'public_suffix_list.dat'
 PublicSuffixListReadOnly = False

--- a/trustymail/trustymail.py
+++ b/trustymail/trustymail.py
@@ -492,7 +492,7 @@ def dmarc_scan(resolver, domain):
                 elif tag == 'rua' or tag == 'ruf':
                     uris = tag_dict[tag].split(',')
                     if len(uris) > 2:
-                        handle_syntax_error('[DMARC]', domain, 'Warning: The {} tag specifies {} URIs.  Receivers are not required to send reports to more than two URIs - https://tools.ietf.org/html/rfc7489#section-6.2.'.format(tag, len(uris)))
+                        handle_error('[DMARC]', domain, 'Warning: The {} tag specifies {} URIs.  Receivers are not required to send reports to more than two URIs - https://tools.ietf.org/html/rfc7489#section-6.2.'.format(tag, len(uris)), syntax_error=False)
                     for uri in uris:
                         # mailto: is currently the only type of DMARC URI
                         parsed_uri = parse_dmarc_report_uri(uri)


### PR DESCRIPTION
WARNING: This should be merged AFTER https://github.com/dhs-ncats/trustymail/pull/98

This pull request updates a few things at the request of DOE HQ folks, specifically:

- Changes the handling of "more than 2 URIs" from a `syntax error` into a `debug info` message (
97d5f53)