### PR TITLE
Modify logic so that the pct tag is allowed to be zero

### DIFF
--- a/trustymail/__init__.py
+++ b/trustymail/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals, absolute_import, print_function
 
-__version__ = '0.6.8'
+__version__ = '0.6.9'
 
 PublicSuffixListFilename = 'public_suffix_list.dat'
 PublicSuffixListReadOnly = False

--- a/trustymail/trustymail.py
+++ b/trustymail/trustymail.py
@@ -481,7 +481,7 @@ def dmarc_scan(resolver, domain):
                 elif tag == 'pct':
                     try:
                         pct = int(tag_dict[tag])
-                        if pct <= 0 or pct > 100:
+                        if pct < 0 or pct > 100:
                             msg = 'Error: invalid DMARC pct tag value: {0} - must be an integer between ' \
                                   '0 and 100'.format(tag_dict[tag])
                             handle_syntax_error('[DMARC]', domain, '{0}'.format(msg))


### PR DESCRIPTION
According to [RFC7489](https://tools.ietf.org/html/rfc7489), the `pct` tag is allowed to be an integer value between `0` and `100`, inclusive.  See [here](https://tools.ietf.org/html/rfc7489#section-6.3) for details.