### PR TITLE
Correctly handle SPF records with include directives

### DIFF
--- a/trustymail/__init__.py
+++ b/trustymail/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals, absolute_import, print_function
 
-__version__ = '0.7.0'
+__version__ = '0.7.1'
 
 PublicSuffixListFilename = 'public_suffix_list.dat'
 PublicSuffixListReadOnly = False

--- a/trustymail/trustymail.py
+++ b/trustymail/trustymail.py
@@ -232,20 +232,22 @@ def check_spf_record(record_text, expected_result, domain, strict=2):
         The level of strictness to use when verifying an SPF record.
         Valid values are True, False, and 2.  The last value is the
         most harsh.
+
     """
     try:
-        # Here I am using the IP address for c1b1.ncats.cyber.dhs.gov
-        # (64.69.57.18) since it (1) has a valid PTR record and (2) is not
-        # listed by anyone as a valid mail server.
-        #
-        # I'm actually temporarily using an IP that virginia.edu resolves to
-        # until we resolve why Google DNS does not return the same PTR records
-        # as the CAL DNS does for 64.69.57.18.
+        # Here I am using the IP address for
+        # ec2-100-27-42-254.compute-1.amazonaws.com (100.27.42.254)
+        # since it (1) has a valid PTR record and (2) is not listed by
+        # anyone as a valid mail server.  (The second item follows
+        # from the fact that AWS has semi-permanently assigned this IP
+        # to NCATS as part of our contiguous netblock, and we are not
+        # using it as a mail server or including it as an MX record
+        # for any domain.)
         #
         # Passing verbose=True causes the SPF library being used to
         # print out the SPF records encountered as include and
         # redirect cause other SPF records to be looked up.
-        query = spf.query('128.143.22.36',
+        query = spf.query('100.27.42.254',
                           'email_wizard@' + domain.domain_name,
                           domain.domain_name, strict=strict, verbose=True)
         response = query.check(spf=record_text)

--- a/trustymail/trustymail.py
+++ b/trustymail/trustymail.py
@@ -152,7 +152,9 @@ def starttls_scan(domain, smtp_timeout, smtp_localhost, smtp_ports, smtp_cache):
                 try:
                     smtp_connection.connect(mail_server, port)
                     domain.starttls_results[server_and_port]['is_listening'] = True
-                except (socket.timeout, smtplib.SMTPConnectError, smtplib.SMTPServerDisconnected, ConnectionRefusedError, OSError) as error:
+                except (socket.timeout, smtplib.SMTPConnectError,
+                        smtplib.SMTPServerDisconnected,
+                        ConnectionRefusedError, OSError) as error:
                     handle_error('[STARTTLS]', domain, error)
                     domain.starttls_results[server_and_port]['is_listening'] = False
                     domain.starttls_results[server_and_port]['supports_smtp'] = False
@@ -316,9 +318,12 @@ def get_spf_record_text(resolver, domain_name, domain, follow_redirect=False):
             match = re.search(r'v=spf1\s*redirect=(\S*)', record_text)
             if follow_redirect and match:
                 redirect_domain_name = match.group(1)
-                record_to_return = get_spf_record_text(resolver, redirect_domain_name, domain)
+                record_to_return = get_spf_record_text(resolver,
+                                                       redirect_domain_name,
+                                                       domain)
             else:
                 record_to_return = record_text
+
         domain.spf_dnssec = check_dnssec(domain, domain.domain_name, 'TXT')
     except (dns.resolver.NoNameservers) as error:
         # The NoNameservers exception means that we got a SERVFAIL response.
@@ -341,8 +346,8 @@ def get_spf_record_text(resolver, domain_name, domain, follow_redirect=False):
 
 def spf_scan(resolver, domain):
     """Scan a domain to see if it supports SPF.  If the domain has an SPF
-    record, verify that it properly rejects mail sent from an IP known
-    to be disallowed.
+    record, verify that it properly handles mail sent from an IP known
+    not to be listed in an MX record for ANY domain.
 
     Parameters
     ----------


### PR DESCRIPTION
Now `pyspf` does all the work for us, and we don't try to check anything manually.  We were doing the manual check incorrectly before, anyway, since if an SPF record has an include directive then the mechanism from the included record is what counts, *not* the mechanism from the initial SPF record for the domain being evaluated.

I also updated the IP that we use when evaluating SPF records.

This pull request resolves #109.