### PR TITLE
Output more data from the SMTP exchange

### DIFF
--- a/trustymail/__init__.py
+++ b/trustymail/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals, absolute_import, print_function
 
-__version__ = '0.7.1'
+__version__ = '0.7.2'
 
 PublicSuffixListFilename = 'public_suffix_list.dat'
 PublicSuffixListReadOnly = False

--- a/trustymail/trustymail.py
+++ b/trustymail/trustymail.py
@@ -155,7 +155,7 @@ def starttls_scan(domain, smtp_timeout, smtp_localhost, smtp_ports, smtp_cache):
                 # The following line is useful when debugging why an
                 # SMTP connection fails.  It prints out all the
                 # traffic sent to and from the SMTP server.
-                # smtp_connection.set_debuglevel(1)
+                smtp_connection.set_debuglevel(1)
                 logging.debug('Testing ' + server_and_port + ' for STARTTLS support')
                 # Try to connect.  This will tell us if something is
                 # listening.


### PR DESCRIPTION
Increase the verbosity of the logging from the smtplib library.  This outputs the text sent and received when performing the SMTP exchange.

We get so many SMTP-related questions that it is worth it to have this information available in the CloudWatch logs.