### PR TITLE
Force smtplib to use IPv4 addresses

### DIFF
--- a/trustymail/__init__.py
+++ b/trustymail/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals, absolute_import, print_function
 
-__version__ = '0.7.2'
+__version__ = '0.7.3'
 
 PublicSuffixListFilename = 'public_suffix_list.dat'
 PublicSuffixListReadOnly = False

--- a/trustymail/trustymail.py
+++ b/trustymail/trustymail.py
@@ -173,11 +173,11 @@ def starttls_scan(domain, smtp_timeout, smtp_localhost, smtp_ports, smtp_cache):
                 # To get around this I look up the A record and use
                 # that instead of the hostname in DNS when I call
                 # smtp_connection.connect().
-                ans = socket.getaddrinfo(
+                addr_info = socket.getaddrinfo(
                     mail_server, port, socket.AF_INET, socket.SOCK_STREAM
                 )
-                sa = ans[0][4]
-                mail_server_ip_address = sa[0]
+                socket_address = addr_info[0][4]
+                mail_server_ip_address = socket_address[0]
 
                 # Try to connect.  This will tell us if something is
                 # listening.

--- a/trustymail/trustymail.py
+++ b/trustymail/trustymail.py
@@ -176,7 +176,6 @@ def starttls_scan(domain, smtp_timeout, smtp_localhost, smtp_ports, smtp_cache):
                 ans = socket.getaddrinfo(
                     mail_server, port, socket.AF_INET, socket.SOCK_STREAM
                 )
-                print(ans)
                 sa = ans[0][4]
                 mail_server_ip_address = sa[0]
 


### PR DESCRIPTION
@climber-girl noticed some cases where the text `[Errno 97] Address family not supported by protocol` appears in the `trustymail` output.  I dug into this, and it appears to happen because, when given a hostname to connect to, `smtplib` asks DNS for all A and AAAA records, tries them in succession, and uses the first one that works.

When running trustymail in AWS Lambda (at least in my VPC, which doesn't support IPv6) the `[Errno 97] Address family not supported by protocol` error appears when an IPv6 connection is attempted.  This makes the connection attempt fail hard, and the other IP addresses returned by DNS are not even attempted.

To get around this, I explicitly get an IPv4 address for the hostname and pass that to smtplib instead.  This way no IPv6 connections are ever attempted.