### PR TITLE
Add a warning for the presence of sp in a subdomain's DMARC record

### DIFF
--- a/trustymail/__init__.py
+++ b/trustymail/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals, absolute_import, print_function
 
-__version__ = '0.7.3'
+__version__ = '0.7.4'
 
 PublicSuffixListFilename = 'public_suffix_list.dat'
 PublicSuffixListReadOnly = False

--- a/trustymail/domain.py
+++ b/trustymail/domain.py
@@ -65,14 +65,15 @@ class Domain:
 
         self.base_domain_name = get_public_suffix(self.domain_name)
 
+        self.is_base_domain = True
+        self.base_domain = None
         if self.base_domain_name != self.domain_name:
+            self.is_base_domain = False
             if self.base_domain_name not in Domain.base_domains:
                 # Populate DMARC for parent.
                 domain = trustymail.scan(self.base_domain_name, timeout, smtp_timeout, smtp_localhost, smtp_ports, smtp_cache, {'mx': False, 'starttls': False, 'spf': False, 'dmarc': True}, dns_hostnames)
                 Domain.base_domains[self.base_domain_name] = domain
             self.base_domain = Domain.base_domains[self.base_domain_name]
-        else:
-            self.base_domain = None
 
         # Start off assuming the host is live unless an error tells us otherwise.
         self.is_live = True

--- a/trustymail/trustymail.py
+++ b/trustymail/trustymail.py
@@ -505,7 +505,7 @@ def dmarc_scan(resolver, domain):
                 tag_dict['pct'] = 100
             if 'adkim' not in tag_dict:
                 tag_dict['adkim'] = 'r'
-            if 'aspf'not in tag_dict:
+            if 'aspf' not in tag_dict:
                 tag_dict['aspf'] = 'r'
             if 'fo' not in tag_dict:
                 tag_dict['fo'] = '0'

--- a/trustymail/trustymail.py
+++ b/trustymail/trustymail.py
@@ -493,6 +493,11 @@ def dmarc_scan(resolver, domain):
                 value = options.split('=')[1].strip()
                 tag_dict[tag] = value
 
+            # Before we set sp=p if it is not explicitly contained in
+            # the DMARC record, log a warning if it is explicitly set
+            # for a subdomain of an organizational domain.
+            if 'sp' in tag_dict and not domain.is_base_domain:
+                handle_error('[DMARC]', domain, 'Warning: The sp tag will be ignored for DMARC records published on subdomains. See here for details:  https://tools.ietf.org/html/rfc7489#section-6.3.', syntax_error=False)
             if 'p' not in tag_dict:
                 msg = 'Record missing required policy (p) tag'
                 handle_syntax_error('[DMARC]', domain, '{0}'.format(msg))


### PR DESCRIPTION
This isn't an error, but according to [RFC7489](https://tools.ietf.org/html/rfc7489#section-6.3),
> "sp" will be ignored for DMARC records published on subdomains of Organizational Domains
due to the effect of the DMARC policy discovery mechanism

Therefore we want to warn users that the `sp` tag they have explicitly set is probably not doing what they intended.  This issue was originally brought to light in NCATS JIRA ticket CYHYDEV-761.

I ran tests against several domains (including `cyber.dhs.gov`, which is a subdomain containing an `sp` tag) and verified that this code behaves as expected.

See also cisagov/trustymail_reporter#33 and jsf9k/cyhy-reports#32.