### PR TITLE
Gracefully handle MX records that do not resolve to an A record

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,6 @@ env:
 # Matrix approach here due to: https://github.com/travis-ci/travis-ci/issues/9815
 matrix:
   include:
-    - python: 3.4
-      dist: xenial
-      sudo: true
-    - python: 3.5
-      dist: xenial
-      sudo: true
     - python: 3.6
       dist: xenial
       sudo: true

--- a/setup.py
+++ b/setup.py
@@ -58,8 +58,6 @@ setup(
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
     ],

--- a/trustymail/__init__.py
+++ b/trustymail/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals, absolute_import, print_function
 
-__version__ = '0.7.4'
+__version__ = '0.7.5'
 
 PublicSuffixListFilename = 'public_suffix_list.dat'
 PublicSuffixListReadOnly = False

--- a/trustymail/trustymail.py
+++ b/trustymail/trustymail.py
@@ -177,7 +177,7 @@ def starttls_scan(domain, smtp_timeout, smtp_localhost, smtp_ports, smtp_cache):
                     addr_info = socket.getaddrinfo(
                         mail_server, port, socket.AF_INET, socket.SOCK_STREAM
                     )
-                except socket.gaierror as error:
+                except socket.gaierror:
                     # We get this exception if there is no A record
                     # for the given mail server.  This does happen,
                     # since among their MX records some domains do


### PR DESCRIPTION
In some cases (`epa.gov` is one) a domain may have some MX records that do not resolve to any A record.  The corresponding mail server is IPv6-only.  Unfortunately our scanning apparatus is IPv4-only.  This case was resulting in an unhandled exception being thrown.

With this change we now gracefully handle an MX record that does not resolve to an IPv4 address. 
Note that we are giving credit for STARTTLS for the mail server, since we cannot evaluate it.