### PR TITLE
Switch helper package for the Public Suffix List

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ setup(
     install_requires=[
         "dnspython",
         "docopt",
-        "publicsuffix",
+        "publicsuffixlist[update]",
         "py3dns",
         "pyspf",
         "requests",

--- a/src/trustymail/_version.py
+++ b/src/trustymail/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this module."""
-__version__ = "0.8.0"
+__version__ = "0.8.1"

--- a/src/trustymail/_version.py
+++ b/src/trustymail/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this module."""
-__version__ = "0.8.1-rc.1"
+__version__ = "0.8.1"

--- a/src/trustymail/_version.py
+++ b/src/trustymail/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this module."""
-__version__ = "0.8.1"
+__version__ = "0.8.1-rc.1"

--- a/src/trustymail/domain.py
+++ b/src/trustymail/domain.py
@@ -20,7 +20,7 @@ def get_psl():
     -------
     PublicSuffixList: An instance of PublicSuffixList loaded with a cached or updated list
     """
-    # Download the psl if necessary
+    # Download the PSL if necessary
     if not PublicSuffixListReadOnly:
         if not path.exists(PublicSuffixListFilename):
             updatePSL(PublicSuffixListFilename)

--- a/src/trustymail/domain.py
+++ b/src/trustymail/domain.py
@@ -7,38 +7,32 @@ from os import path, stat
 from typing import Dict
 
 # Third-Party Libraries
-import publicsuffix
+from publicsuffixlist.compat import PublicSuffixList
+from publicsuffixlist.update import updatePSL
 
 from . import PublicSuffixListFilename, PublicSuffixListReadOnly, trustymail
 
 
 def get_psl():
-    """
-    Get the Public Suffix List - either new, or cached in the CWD for 24 hours.
+    """Get the Public Suffix List - either new, or cached in the CWD for 24 hours.
 
     Returns
     -------
     PublicSuffixList: An instance of PublicSuffixList loaded with a cached or updated list
     """
-
-    def download_psl():
-        fresh_psl = publicsuffix.fetch()
-        with open(PublicSuffixListFilename, "w", encoding="utf-8") as fresh_psl_file:
-            fresh_psl_file.write(fresh_psl.read())
-
     # Download the psl if necessary
     if not PublicSuffixListReadOnly:
         if not path.exists(PublicSuffixListFilename):
-            download_psl()
+            updatePSL(PublicSuffixListFilename)
         else:
             psl_age = datetime.now() - datetime.fromtimestamp(
                 stat(PublicSuffixListFilename).st_mtime
             )
             if psl_age > timedelta(hours=24):
-                download_psl()
+                updatePSL(PublicSuffixListFilename)
 
     with open(PublicSuffixListFilename, encoding="utf-8") as psl_file:
-        psl = publicsuffix.PublicSuffixList(psl_file)
+        psl = PublicSuffixList(psl_file)
 
     return psl
 


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request switches [Public Suffix List] helper packages from [publicsuffix] to [publicsuffixlist]. Any necessary supporting changes are also made.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The [publicsuffix] package is deprecated and has not been maintained for years. It finally reached a breaking point during this past weekend's BOD 18-01 scanning run where the server hosting the maintained public suffix list no longer returned the `charset` header that [publicsuffix] expects. The [publicsuffixlist] package is the currently maintained one of the two alternatives mentioned by [publicsuffix] and it has a compatibility layer for existing code that uses [publicsuffix].
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🔔 See also ##

- https://github.com/cisagov/pshtt/pull/237
- https://github.com/cisagov/domain-scan/pull/2

## 🧪 Testing ##

Automated tests pass. I confirmed that I was able to perform a local scan using this branch.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been approved. -->

- [x] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [x] Create a release.

[Public Suffix List]: https://publicsuffix.org/
[publicsuffix]: https://pypi.org/project/publicsuffix/
[publicsuffixlist]: https://pypi.org/project/publicsuffixlist