### PR TITLE
Fixes issue 132 (Public Suffix List (PSL) Updates Too Often)

### DIFF
--- a/src/trustymail/_version.py
+++ b/src/trustymail/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this module."""
-__version__ = "0.8.2-rc.1"
+__version__ = "0.8.2"

--- a/src/trustymail/_version.py
+++ b/src/trustymail/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this module."""
-__version__ = "0.8.1"
+__version__ = "0.8.2"

--- a/src/trustymail/_version.py
+++ b/src/trustymail/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this module."""
-__version__ = "0.8.2"
+__version__ = "0.8.2-rc.1"

--- a/src/trustymail/domain.py
+++ b/src/trustymail/domain.py
@@ -24,14 +24,14 @@ def get_psl():
     if not PublicSuffixListReadOnly:
         if not path.exists(PublicSuffixListFilename):
             updatePSL(PublicSuffixListFilename)
-            utime(PublicSuffixListFilename, None) # Set mtime to now
+            utime(PublicSuffixListFilename, None)  # Set mtime to now
         else:
             psl_age = datetime.now() - datetime.fromtimestamp(
                 stat(PublicSuffixListFilename).st_mtime
             )
             if psl_age > timedelta(hours=24):
                 updatePSL(PublicSuffixListFilename)
-                utime(PublicSuffixListFilename, None) # Set mtime to now
+                utime(PublicSuffixListFilename, None)  # Set mtime to now
 
     with open(PublicSuffixListFilename, encoding="utf-8") as psl_file:
         psl = PublicSuffixList(psl_file)

--- a/src/trustymail/domain.py
+++ b/src/trustymail/domain.py
@@ -3,7 +3,7 @@
 # Standard Python Libraries
 from collections import OrderedDict
 from datetime import datetime, timedelta
-from os import path, stat
+from os import path, stat, utime
 from typing import Dict
 
 # Third-Party Libraries
@@ -24,12 +24,15 @@ def get_psl():
     if not PublicSuffixListReadOnly:
         if not path.exists(PublicSuffixListFilename):
             updatePSL(PublicSuffixListFilename)
+            utime(PublicSuffixListFilename, None) # Set mtime to now
         else:
             psl_age = datetime.now() - datetime.fromtimestamp(
                 stat(PublicSuffixListFilename).st_mtime
             )
             if psl_age > timedelta(hours=24):
                 updatePSL(PublicSuffixListFilename)
+                utime(PublicSuffixListFilename, None) # Set mtime to now
+
 
     with open(PublicSuffixListFilename, encoding="utf-8") as psl_file:
         psl = PublicSuffixList(psl_file)

--- a/src/trustymail/domain.py
+++ b/src/trustymail/domain.py
@@ -33,7 +33,6 @@ def get_psl():
                 updatePSL(PublicSuffixListFilename)
                 utime(PublicSuffixListFilename, None) # Set mtime to now
 
-
     with open(PublicSuffixListFilename, encoding="utf-8") as psl_file:
         psl = PublicSuffixList(psl_file)
 


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
Added code to set the PSL file's last modified time to reflect time of last download.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##
PSL should only be downloaded once per day. The current code attempts to enforce that by only downloading a new PSL, when the local copy is older than 24 hours:
```
psl_age = datetime.now() - datetime.fromtimestamp(
    stat(PublicSuffixListFilename).st_mtime
)
if psl_age > timedelta(hours=24):
    updatePSL(PublicSuffixListFilename)
```
stat.st_mtime checks the last modified date of the local PSL, however, the last modified date will often be 2-4 days ago  even if the PSL was downloaded minutes before.

Resolves #132.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
I ran Trustymail against an array of domains.
The first domain was tested and then the code waited for a local PSL to be created before testing the remaining domains. I logged all STDOUT to see if the "PSL Updated" message appeared more than once.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [x] Create a release.
