### PR TITLE
updated RFC 4408 citation to RFC 7208 and added link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ The following values are returned in `results.csv`:
 - `SPF Record DNSSEC` - A boolean value indicating whether or not the
   DNS record is protected by DNSSEC.
 - `Valid SPF` - Whether the SPF record found is syntactically correct,
-  per RFC 4408.
+  per [RFC 7208](https://datatracker.ietf.org/doc/html/rfc7208).
 - `SPF Results` - The textual representation of any SPF record found
   for the domain.
 


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->
This pull request updates the README's RFC 4408 citation to RFC 7208 and adds a link thereto.

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->
We do not want `trustymail` documentation (or code) to cite superseded references.  RFC 7208 superseded RFC 4408.  Resolves #136.

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
After making the change to the README, I pushed the change to my forked repo and could proof-read the text and test the link from there.

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.
