### PR TITLE
fix: unused psl arguments

### DIFF
--- a/src/trustymail/__init__.py
+++ b/src/trustymail/__init__.py
@@ -9,6 +9,3 @@ from typing import List
 from ._version import __version__  # noqa: F401
 
 __all__: List[str] = []
-
-PublicSuffixListFilename = "public_suffix_list.dat"
-PublicSuffixListReadOnly = False

--- a/src/trustymail/cli.py
+++ b/src/trustymail/cli.py
@@ -72,9 +72,13 @@ def main():
     # Monkey patching trustymail to make it cache the PSL where we want
     if args["--psl-filename"] is not None:
         trustymail.PublicSuffixListFilename = args["--psl-filename"]
+    else:
+        trustymail.PublicSuffixListFilename = "public_suffix_list.dat"
     # Monkey patching trustymail to make the PSL cache read-only
     if args["--psl-read-only"]:
         trustymail.PublicSuffixListReadOnly = True
+    else:
+        trustymail.PublicSuffixListReadOnly = False
     # cisagov Libraries
     import trustymail.trustymail as tmail
 

--- a/src/trustymail/domain.py
+++ b/src/trustymail/domain.py
@@ -10,7 +10,7 @@ from typing import Dict
 from publicsuffixlist.compat import PublicSuffixList
 from publicsuffixlist.update import updatePSL
 
-from . import PublicSuffixListFilename, PublicSuffixListReadOnly, trustymail
+from . import trustymail
 
 
 def get_psl():
@@ -21,17 +21,17 @@ def get_psl():
     PublicSuffixList: An instance of PublicSuffixList loaded with a cached or updated list
     """
     # Download the PSL if necessary
-    if not PublicSuffixListReadOnly:
-        if not path.exists(PublicSuffixListFilename):
-            updatePSL(PublicSuffixListFilename)
+    if not trustymail.PublicSuffixListReadOnly:
+        if not path.exists(trustymail.PublicSuffixListFilename):
+            updatePSL(trustymail.PublicSuffixListFilename)
         else:
             psl_age = datetime.now() - datetime.fromtimestamp(
-                stat(PublicSuffixListFilename).st_mtime
+                stat(trustymail.PublicSuffixListFilename).st_mtime
             )
             if psl_age > timedelta(hours=24):
-                updatePSL(PublicSuffixListFilename)
+                updatePSL(trustymail.PublicSuffixListFilename)
 
-    with open(PublicSuffixListFilename, encoding="utf-8") as psl_file:
+    with open(trustymail.PublicSuffixListFilename, encoding="utf-8") as psl_file:
         psl = PublicSuffixList(psl_file)
 
     return psl


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
The `--psl-filename=FILENAME` and `--psl-read-only` arguments are not working. The variables that get the values from the user's arguments are different from the variables that are used in `get_psl` function.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##
The arguments are not working when I assign the file path to public suffix list.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
1. Run `pip install git+https://github.com/stanley101music/trustymail@modify-psl-parameters`
2. Run `trustymail google.com`
3. Confirm the default values are correct, and the `public_suffix_list.dat` are downloaded in the current folder
4. Change the filename of `public_suffix_list.dat` to `exists_psl.dat`
5. Change the last modified time of `exists_psl.dat` by `touch -m exists_psl.dat`
6. Run `trustymail --psl-filename=exists_psl.dat google.com`
7. Confirm that there is no need to call `updatePSL`
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release.
