### PR TITLE
Fix incorrect CLI option name in comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,12 +80,11 @@ output will always be written to disk, defaulting to `results.csv`.
   --debug                     Output should include more verbose logging.
   --dns=HOSTNAMES             A comma-delimited list of DNS servers to query
                               against.  For example, if you want to use
-                              Google's DNS then you would use the
-                              value --dns-hostnames='8.8.8.8,8.8.4.4'.  By
-                              default the DNS configuration of the host OS
-                              (/etc/resolv.conf) is used.  Note that
-                              the host's DNS configuration is not used at all
-                              if this option is used.
+                              Google's DNS then you would use the value
+                              --dns='8.8.8.8,8.8.4.4'.  By default the DNS
+                              configuration of the host OS (/etc/resolv.conf) is
+                              used.  Note that the host's DNS configuration is
+                              not used at all if this option is used.
   --psl-filename=FILENAME     The name of the file where the public suffix list
                               (PSL) cache will be saved.  If set to the name of
                               an existing file then that file will be used as

--- a/src/trustymail/cli.py
+++ b/src/trustymail/cli.py
@@ -27,12 +27,11 @@ Options:
   --debug                     Output should include more verbose logging.
   --dns=HOSTNAMES             A comma-delimited list of DNS servers to query
                               against.  For example, if you want to use
-                              Google's DNS then you would use the
-                              value --dns-hostnames='8.8.8.8,8.8.4.4'.  By
-                              default the DNS configuration of the host OS
-                              (/etc/resolv.conf) is used.  Note that
-                              the host's DNS configuration is not used at all
-                              if this option is used.
+                              Google's DNS then you would use the value
+                              --dns='8.8.8.8,8.8.4.4'.  By default the DNS
+                              configuration of the host OS (/etc/resolv.conf) is
+                              used.  Note that the host's DNS configuration is
+                              not used at all if this option is used.
   --psl-filename=FILENAME     The name of the file where the public suffix list
                               (PSL) cache will be saved.  If set to the name of
                               an existing file then that file will be used as


### PR DESCRIPTION
## 🗣 Description ##

This pull request fixes a reference to a CLI option that used the wrong name.

## 💭 Motivation and context ##

Resolves #158.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.